### PR TITLE
feat: P0 event-driven scheduler — persona.idle/blocked events

### DIFF
--- a/src/opencompany/company/engine.py
+++ b/src/opencompany/company/engine.py
@@ -28,14 +28,56 @@ async def set_persona_state(persona_id: str, state: str) -> None:
 
 
 async def handle_event(event_type: str, data: dict):
-    """Handle events from the bus."""
+    """Handle events from the bus.
+
+    Event-driven scheduler: reacts to lifecycle events immediately
+    instead of waiting for periodic sweep ticks.
+    """
     try:
         if event_type == "ticket.created":
             await _route_ticket(data["ticket_id"])
         elif event_type == "ticket.review":
             await _trigger_review(data["ticket_id"])
+        elif event_type == "persona.idle":
+            await _on_persona_idle(data["persona_id"])
+        elif event_type == "persona.blocked":
+            logger.info(
+                "Persona %s blocked (reason=%s)",
+                data.get("persona_id"),
+                data.get("reason", "unknown"),
+            )
     except Exception:
         logger.exception("Error handling event %s: %s", event_type, data)
+
+
+async def _on_persona_idle(persona_id: str) -> None:
+    """React to a persona becoming idle: immediately try to assign next ticket.
+
+    This is the core of the event-driven scheduler — assignment latency drops
+    from SWEEP_INTERVAL seconds to milliseconds.
+    """
+    async with async_session() as session:
+        persona = await session.get(Persona, persona_id)
+        if not persona or persona.status != "active":
+            return
+
+    if persona.type == "solver":
+        claimed = await claim_next(persona_id)
+        if not claimed:
+            return
+        logger.info(
+            "Event-driven pickup: %s claimed ticket #%d",
+            persona_id,
+            claimed["id"],
+        )
+        _spawn_persona_task(
+            persona,
+            _build_task_prompt_from_dict(claimed),
+            f"solve-ticket-{claimed['id']}",
+            ticket_id=claimed["id"],
+        )
+    elif persona_id == "hr":
+        await _hr_pickup()
 
 
 async def _route_ticket(ticket_id: int):
@@ -352,6 +394,10 @@ def _spawn_persona_task(persona: Persona, task: str, label: str, ticket_id: int 
                 label,
             )
             await set_persona_state(persona.id, "blocked")
+            await publish(
+                "persona.blocked",
+                {"persona_id": persona.id, "reason": "daily_budget_exhausted"},
+            )
             return
 
         # Per-task budget gate: check if ticket has enough budget left
@@ -384,13 +430,15 @@ def _spawn_persona_task(persona: Persona, task: str, label: str, ticket_id: int 
         except Exception:
             logger.exception("Background persona task %s failed", label)
             await set_persona_state(persona.id, "blocked")
+            await publish(
+                "persona.blocked",
+                {"persona_id": persona.id, "reason": "task_error"},
+            )
         else:
             await set_persona_state(persona.id, "idle")
-            # Greedy: look for next unassigned ticket
-            if persona.type == "solver":
-                await _greedy_pickup(persona)
-            elif persona.id == "hr":
-                await _hr_pickup()
+            # Publish idle event — the event-driven scheduler will
+            # immediately try to assign the next ticket via _on_persona_idle
+            await publish("persona.idle", {"persona_id": persona.id})
 
     t = asyncio.create_task(_run(), name=label)
     _running_tasks.add(t)
@@ -478,30 +526,6 @@ async def _check_task_budget_post_run(ticket_id: int) -> None:
                 used,
                 ticket.budget_tokens,
             )
-
-
-async def _greedy_pickup(persona: Persona) -> None:
-    """After finishing a task, solver claims the next best-match ticket via pull."""
-    try:
-        load_company_config()
-    except FileNotFoundError:
-        return
-
-    claimed = await claim_next(persona.id)
-    if not claimed:
-        return
-
-    logger.info(
-        "Greedy pickup: %s claimed ticket #%d",
-        persona.id,
-        claimed["id"],
-    )
-    _spawn_persona_task(
-        persona,
-        _build_task_prompt_from_dict(claimed),
-        f"solve-ticket-{claimed['id']}",
-        ticket_id=claimed["id"],
-    )
 
 
 _HR_TAGS = {"hr", "hiring", "firing", "headcount", "personnel", "recruit"}

--- a/tests/test_engine_cov.py
+++ b/tests/test_engine_cov.py
@@ -382,17 +382,17 @@ async def test_spawn_persona_task_error_sets_blocked(db_engine):
 
 
 # ---------------------------------------------------------------------------
-# _greedy_pickup
+# _on_persona_idle (event-driven scheduler, replaces _greedy_pickup)
 # ---------------------------------------------------------------------------
-async def test_greedy_pickup_finds_matching_ticket(db_engine):
-    """Greedy pickup routes the best matching open ticket."""
+async def test_on_persona_idle_claims_ticket(db_engine):
+    """_on_persona_idle claims the best matching open ticket for a solver."""
     factory = async_sessionmaker(db_engine, expire_on_commit=False)
 
     async with factory() as session:
         session.add(
             Persona(
-                id="greedy-dev",
-                name="Greedy Dev",
+                id="idle-dev",
+                name="Idle Dev",
                 role="Dev",
                 type="solver",
                 skills=["python"],
@@ -415,26 +415,19 @@ async def test_greedy_pickup_finds_matching_ticket(db_engine):
         patch("opencompany.company.engine.async_session", factory),
         patch("opencompany.company.taskboard.async_session", factory),
         patch("opencompany.company.engine.run_persona", new_callable=AsyncMock),
-        patch(
-            "opencompany.company.engine.load_company_config",
-            return_value=_TEST_CONFIG,
-        ),
     ):
-        from opencompany.company.engine import _greedy_pickup
+        from opencompany.company.engine import _on_persona_idle
 
-        async with factory() as session:
-            persona = await session.get(Persona, "greedy-dev")
-
-        await _greedy_pickup(persona)
+        await _on_persona_idle("idle-dev")
 
     async with factory() as session:
         ticket = await session.get(Ticket, ticket_id)
-        assert ticket.assigned_to == "greedy-dev"
+        assert ticket.assigned_to == "idle-dev"
         assert ticket.status == "assigned"
 
 
-async def test_greedy_pickup_no_orphans(db_engine):
-    """Greedy pickup does nothing when no open tickets exist."""
+async def test_on_persona_idle_no_tickets(db_engine):
+    """_on_persona_idle does nothing when no open tickets exist."""
     factory = async_sessionmaker(db_engine, expire_on_commit=False)
 
     async with factory() as session:
@@ -454,33 +447,35 @@ async def test_greedy_pickup_no_orphans(db_engine):
     with (
         patch("opencompany.company.engine.async_session", factory),
         patch("opencompany.company.taskboard.async_session", factory),
-        patch("opencompany.company.engine.load_company_config", return_value=_TEST_CONFIG),
     ):
-        from opencompany.company.engine import _greedy_pickup
+        from opencompany.company.engine import _on_persona_idle
 
-        async with factory() as session:
-            persona = await session.get(Persona, "idle-dev")
-
-        await _greedy_pickup(persona)
-
-    # No open tickets → claim_next returns None → no task spawned
+        # Should not raise, no task spawned
+        await _on_persona_idle("idle-dev")
 
 
-async def test_greedy_pickup_no_config():
-    """Greedy pickup exits early when no company config exists."""
-    with patch(
-        "opencompany.company.engine.load_company_config",
-        side_effect=FileNotFoundError,
-    ):
-        from opencompany.company.engine import _greedy_pickup
+async def test_on_persona_idle_inactive_persona(db_engine):
+    """_on_persona_idle does nothing for inactive personas."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
 
-        persona = MagicMock()
-        persona.type = "solver"
-        persona.picks_up = ["backend"]
-        persona.skills = ["python"]
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="fired-dev",
+                name="Fired Dev",
+                role="Dev",
+                type="solver",
+                status="fired",
+                backstory="Gone.",
+            )
+        )
+        await session.commit()
+
+    with patch("opencompany.company.engine.async_session", factory):
+        from opencompany.company.engine import _on_persona_idle
 
         # Should not raise
-        await _greedy_pickup(persona)
+        await _on_persona_idle("fired-dev")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sprint2_events.py
+++ b/tests/test_sprint2_events.py
@@ -1,0 +1,176 @@
+"""Tests for Sprint 2: event-driven scheduler (P0)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from opencompany.models.db import Persona
+
+
+@pytest.fixture
+async def factory(db_engine):
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+async def test_handle_event_dispatches_persona_idle(db_engine):
+    """handle_event routes persona.idle to _on_persona_idle."""
+    with patch("opencompany.company.engine._on_persona_idle", new_callable=AsyncMock) as mock:
+        from opencompany.company.engine import handle_event
+
+        await handle_event("persona.idle", {"persona_id": "dev-1"})
+        mock.assert_awaited_once_with("dev-1")
+
+
+async def test_handle_event_handles_persona_blocked():
+    """handle_event logs persona.blocked without error."""
+    from opencompany.company.engine import handle_event
+
+    # Should not raise
+    await handle_event("persona.blocked", {"persona_id": "dev-1", "reason": "budget"})
+
+
+async def test_spawn_publishes_idle_on_success(db_engine):
+    """_spawn_persona_task publishes persona.idle when task completes."""
+    import asyncio
+
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="pub-dev",
+                name="Pub Dev",
+                role="Dev",
+                type="solver",
+                skills=["python"],
+                backstory="Test.",
+                activity_state="idle",
+                daily_token_budget=100000,
+            )
+        )
+        await session.commit()
+
+    from unittest.mock import MagicMock
+
+    mock_result = MagicMock()
+    mock_result.input_tokens = 100
+    mock_result.output_tokens = 50
+
+    published_events = []
+    original_publish = AsyncMock(side_effect=lambda t, d: published_events.append((t, d)))
+
+    with (
+        patch("opencompany.company.engine.async_session", factory),
+        patch(
+            "opencompany.company.engine.run_persona",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ),
+        patch("opencompany.company.budget.async_session", factory),
+        patch("opencompany.company.engine.publish", original_publish),
+    ):
+        from opencompany.company.engine import _spawn_persona_task
+
+        async with factory() as session:
+            persona = await session.get(Persona, "pub-dev")
+
+        _spawn_persona_task(persona, "Do work", "test-pub")
+        await asyncio.sleep(0.5)
+
+    idle_events = [(t, d) for t, d in published_events if t == "persona.idle"]
+    assert len(idle_events) == 1
+    assert idle_events[0][1]["persona_id"] == "pub-dev"
+
+
+async def test_spawn_publishes_blocked_on_error(db_engine):
+    """_spawn_persona_task publishes persona.blocked when task fails."""
+    import asyncio
+
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="err-dev",
+                name="Error Dev",
+                role="Dev",
+                type="solver",
+                skills=["python"],
+                backstory="Will error.",
+                activity_state="idle",
+                daily_token_budget=100000,
+            )
+        )
+        await session.commit()
+
+    published_events = []
+    original_publish = AsyncMock(side_effect=lambda t, d: published_events.append((t, d)))
+
+    with (
+        patch("opencompany.company.engine.async_session", factory),
+        patch(
+            "opencompany.company.engine.run_persona",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("LLM down"),
+        ),
+        patch("opencompany.company.budget.async_session", factory),
+        patch("opencompany.company.engine.publish", original_publish),
+    ):
+        from opencompany.company.engine import _spawn_persona_task
+
+        async with factory() as session:
+            persona = await session.get(Persona, "err-dev")
+
+        _spawn_persona_task(persona, "Do work", "test-err")
+        await asyncio.sleep(0.5)
+
+    blocked_events = [(t, d) for t, d in published_events if t == "persona.blocked"]
+    assert len(blocked_events) == 1
+    assert blocked_events[0][1]["persona_id"] == "err-dev"
+    assert blocked_events[0][1]["reason"] == "task_error"
+
+
+async def test_spawn_publishes_blocked_on_budget_exhausted(db_engine):
+    """_spawn_persona_task publishes persona.blocked when over daily budget."""
+    import asyncio
+    from datetime import UTC, datetime
+
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="broke-dev",
+                name="Broke Dev",
+                role="Dev",
+                type="solver",
+                skills=["python"],
+                backstory="No budget.",
+                activity_state="idle",
+                daily_token_budget=100,
+                tokens_used_today=200,  # over budget
+                budget_reset_at=datetime.now(UTC),  # reset today so it won't auto-reset
+            )
+        )
+        await session.commit()
+
+    published_events = []
+    mock_publish = AsyncMock(side_effect=lambda t, d: published_events.append((t, d)))
+
+    with (
+        patch("opencompany.company.engine.async_session", factory),
+        patch("opencompany.company.budget.async_session", factory),
+        patch("opencompany.company.engine.publish", mock_publish),
+    ):
+        from opencompany.company.engine import _spawn_persona_task
+
+        async with factory() as session:
+            persona = await session.get(Persona, "broke-dev")
+
+        _spawn_persona_task(persona, "Do work", "test-broke")
+        await asyncio.sleep(0.5)
+
+    blocked_events = [(t, d) for t, d in published_events if t == "persona.blocked"]
+    assert len(blocked_events) == 1
+    assert blocked_events[0][1]["reason"] == "daily_budget_exhausted"


### PR DESCRIPTION
## Summary

- Publish `persona.idle` on task completion and `persona.blocked` on budget/error from `_spawn_persona_task`
- Add `_on_persona_idle` handler that calls `claim_next` for immediate assignment
- Replace direct `_greedy_pickup` calls with event publishing through Redis bus
- Assignment latency: sweep interval (30s) → milliseconds
- 30s sweep remains as safety net for missed events

## Test plan
- [x] 5 new tests in `tests/test_sprint2_events.py`
- [x] Updated existing greedy_pickup tests → `_on_persona_idle` tests
- [x] Zero regressions