### PR TITLE
feat: P5 efficiency metrics endpoint

### DIFF
--- a/src/opencompany/gateway/api.py
+++ b/src/opencompany/gateway/api.py
@@ -6,12 +6,13 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
+from sqlalchemy import func as sa_func
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opencompany.agents.runner import run_persona
 from opencompany.events.bus import publish
-from opencompany.models.db import Persona, Ticket
+from opencompany.models.db import Persona, Ticket, WorkLog
 from opencompany.models.engine import get_session
 
 logger = logging.getLogger(__name__)
@@ -231,6 +232,49 @@ async def api_reset_all_budgets():
 
     count = await reset_all_budgets()
     return {"status": "ok", "reset_count": count}
+
+
+# --- Efficiency metrics endpoint ---
+
+
+@router.get("/metrics/efficiency", dependencies=[Depends(verify_api_key)])
+async def api_efficiency_metrics(session: AsyncSession = Depends(get_session)):
+    """Per-persona efficiency metrics: tasks completed, tokens used, avg duration."""
+    q = (
+        select(
+            Persona.id,
+            Persona.name,
+            Persona.role,
+            sa_func.count(WorkLog.id).label("tasks_completed"),
+            sa_func.sum(Ticket.tokens_in + Ticket.tokens_out).label("total_tokens"),
+            sa_func.avg(WorkLog.duration_sec).label("avg_duration_sec"),
+        )
+        .join(WorkLog, WorkLog.persona_id == Persona.id)
+        .outerjoin(Ticket, WorkLog.ticket_id == Ticket.id)
+        .where(WorkLog.action.in_(["solved", "review", "done"]))
+        .group_by(Persona.id, Persona.name, Persona.role)
+        .order_by(sa_func.sum(Ticket.tokens_in + Ticket.tokens_out).desc().nulls_last())
+    )
+    result = await session.execute(q)
+    rows = result.all()
+
+    metrics = []
+    for row in rows:
+        total_tokens = row.total_tokens or 0
+        tasks = row.tasks_completed or 0
+        metrics.append(
+            {
+                "persona_id": row.id,
+                "name": row.name,
+                "role": row.role,
+                "tasks_completed": tasks,
+                "total_tokens": total_tokens,
+                "tokens_per_task": round(total_tokens / tasks) if tasks else 0,
+                "avg_duration_sec": round(row.avg_duration_sec or 0, 1),
+            }
+        )
+
+    return metrics
 
 
 # --- Reset endpoint ---

--- a/tests/test_sprint3_metrics.py
+++ b/tests/test_sprint3_metrics.py
@@ -1,0 +1,119 @@
+"""Tests for Sprint 3: efficiency metrics endpoint (P5)."""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from opencompany.models.db import Persona, Ticket, WorkLog
+
+
+@pytest.fixture
+async def factory(db_engine):
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+async def test_metrics_returns_per_persona_data(db_engine):
+    """Metrics endpoint returns tasks_completed, total_tokens, tokens_per_task."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="metrics-dev",
+                name="Metrics Dev",
+                role="Dev",
+                type="solver",
+                backstory="x",
+            )
+        )
+        t1 = Ticket(
+            title="Task 1",
+            tags=["x"],
+            status="done",
+            tokens_in=500,
+            tokens_out=200,
+            assigned_to="metrics-dev",
+        )
+        session.add(t1)
+        await session.flush()
+        session.add(
+            WorkLog(
+                persona_id="metrics-dev",
+                action="done",
+                ticket_id=t1.id,
+                duration_sec=30,
+            )
+        )
+
+        t2 = Ticket(
+            title="Task 2",
+            tags=["x"],
+            status="done",
+            tokens_in=300,
+            tokens_out=100,
+            assigned_to="metrics-dev",
+        )
+        session.add(t2)
+        await session.flush()
+        session.add(
+            WorkLog(
+                persona_id="metrics-dev",
+                action="done",
+                ticket_id=t2.id,
+                duration_sec=20,
+            )
+        )
+        await session.commit()
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from opencompany.gateway.api import router
+    from opencompany.models.engine import get_session
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    async def override_session():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/metrics/efficiency")
+        assert resp.status_code == 200
+        data = resp.json()
+
+    assert len(data) >= 1
+    dev = next(m for m in data if m["persona_id"] == "metrics-dev")
+    assert dev["tasks_completed"] == 2
+    assert dev["total_tokens"] == 1100  # (500+200) + (300+100)
+    assert dev["tokens_per_task"] == 550
+    assert dev["avg_duration_sec"] == 25.0
+
+
+async def test_metrics_empty_when_no_work(db_engine):
+    """Metrics endpoint returns empty list when no completed work."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from opencompany.gateway.api import router
+    from opencompany.models.engine import get_session
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    async def override_session():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/metrics/efficiency")
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
## Summary

- Add `GET /api/metrics/efficiency` endpoint returning per-persona metrics
- Aggregates WorkLog + Ticket data: tasks_completed, total_tokens, tokens_per_task, avg_duration_sec
- Ordered by cost (most expensive persona first) for tuning

## Test plan
- [x] 2 new tests in `tests/test_sprint3_metrics.py`
- [x] Zero regressions