### PR TITLE
feat: P6 DB-backed persona config with live editor and snapshots

### DIFF
--- a/src/opencompany/company/config.py
+++ b/src/opencompany/company/config.py
@@ -118,6 +118,57 @@ def invalidate_cache() -> None:
     _cached_mtime = 0.0
 
 
+async def boot_persona_configs(yaml_path: str | None = None) -> int:
+    """Seed PersonaConfig table from company.yaml on first start.
+
+    Skips if DB already has persona configs (i.e. company is already running).
+    Returns the number of configs seeded.
+    """
+    from sqlalchemy import func, select
+
+    from opencompany.models.db import PersonaConfig
+    from opencompany.models.engine import async_session
+
+    async with async_session() as session:
+        count = await session.scalar(select(func.count(PersonaConfig.id)))
+        if count and count > 0:
+            logger.info("PersonaConfig already seeded (%d entries), skipping", count)
+            return 0
+
+    config = load_company_config(yaml_path)
+
+    seeded = 0
+    async with async_session() as session:
+        for role_id, role_data in config.roles.items():
+            pc = PersonaConfig(
+                id=role_id,
+                name=role_data.get("name", role_id),
+                role=role_id,
+                trust=_trust_from_type(role_data.get("type", "solver")),
+                skills=role_data.get("tag_match", []),
+                budget_tokens_daily=role_data.get("daily_token_budget", 0),
+                instructions=role_data.get("responsibilities", ""),
+                personality=role_data.get("personality", {}),
+                updated_by="system",
+            )
+            session.add(pc)
+            seeded += 1
+        await session.commit()
+
+    logger.info("Seeded %d persona configs from YAML", seeded)
+    return seeded
+
+
+def _trust_from_type(role_type: str) -> str:
+    """Map role type to trust tier."""
+    return {
+        "manager": "full",
+        "lead": "lead",
+        "solver": "solver",
+        "observer": "external",
+    }.get(role_type, "solver")
+
+
 def add_role(
     role_id: str,
     role_type: str,

--- a/src/opencompany/company/scheduler.py
+++ b/src/opencompany/company/scheduler.py
@@ -178,6 +178,73 @@ async def _expire_stale_assignments_job():
         logger.exception("Stale assignment expiry job failed")
 
 
+async def snapshot_company(trigger: str = "interval") -> None:
+    """Capture all PersonaConfigs + ticket stats to CompanySnapshot."""
+    try:
+        from sqlalchemy import func, select
+
+        from opencompany.models.db import CompanySnapshot, PersonaConfig, Ticket
+        from opencompany.models.engine import async_session
+
+        async with async_session() as session:
+            configs = (await session.execute(select(PersonaConfig))).scalars().all()
+            if not configs:
+                return  # nothing to snapshot
+
+            # Gather ticket stats
+            open_count = (
+                await session.scalar(select(func.count(Ticket.id)).where(Ticket.status == "open"))
+                or 0
+            )
+            done_count = (
+                await session.scalar(select(func.count(Ticket.id)).where(Ticket.status == "done"))
+                or 0
+            )
+            in_progress_count = (
+                await session.scalar(
+                    select(func.count(Ticket.id)).where(Ticket.status == "in_progress")
+                )
+                or 0
+            )
+
+            snapshot_data = {
+                "personas": [
+                    {
+                        "id": c.id,
+                        "name": c.name,
+                        "role": c.role,
+                        "trust": c.trust,
+                        "skills": c.skills,
+                        "budget_tokens_daily": c.budget_tokens_daily,
+                    }
+                    for c in configs
+                ],
+                "tickets": {
+                    "open": open_count,
+                    "in_progress": in_progress_count,
+                    "done": done_count,
+                },
+            }
+
+            session.add(
+                CompanySnapshot(
+                    trigger=trigger,
+                    snapshot=snapshot_data,
+                )
+            )
+            await session.commit()
+            logger.info("Company snapshot saved [%s]", trigger)
+    except Exception:
+        logger.exception("Company snapshot failed")
+
+
+_SNAPSHOT_INTERVAL = int(os.environ.get("SNAPSHOT_INTERVAL_SECONDS", "300"))
+
+
+async def _snapshot_job():
+    await snapshot_company("interval")
+
+
 def start_scheduler():
     scheduler.add_job(_sweep_job, "interval", seconds=30, id="sweep_unassigned")
     scheduler.add_job(
@@ -186,6 +253,14 @@ def start_scheduler():
         seconds=120,
         id="expire_stale_assignments",
     )
+    if _SNAPSHOT_INTERVAL > 0:
+        scheduler.add_job(
+            _snapshot_job,
+            "interval",
+            seconds=_SNAPSHOT_INTERVAL,
+            id="company_snapshot",
+        )
+        logger.info("Company snapshot enabled: every %d seconds", _SNAPSHOT_INTERVAL)
 
     ceo_interval = int(os.environ.get("CEO_KICKOFF_INTERVAL_SECONDS", "0"))
     if ceo_interval > 0:

--- a/src/opencompany/gateway/api.py
+++ b/src/opencompany/gateway/api.py
@@ -234,6 +234,107 @@ async def api_reset_all_budgets():
     return {"status": "ok", "reset_count": count}
 
 
+# --- Persona config endpoints ---
+
+
+class PersonaConfigOut(BaseModel):
+    id: str
+    name: str
+    role: str
+    trust: str
+    skills: list
+    budget_tokens_daily: int
+    instructions: str
+    personality: dict
+    updated_by: str
+
+    model_config = {"from_attributes": True}
+
+
+class PersonaConfigPatch(BaseModel):
+    instructions: str | None = None
+    budget_tokens_daily: int | None = None
+    personality: dict | None = None
+    skills: list[str] | None = None
+
+
+@router.get(
+    "/config/personas",
+    response_model=list[PersonaConfigOut],
+    dependencies=[Depends(verify_api_key)],
+)
+async def api_list_persona_configs(
+    session: AsyncSession = Depends(get_session),
+):
+    from opencompany.models.db import PersonaConfig
+
+    result = await session.execute(select(PersonaConfig))
+    return result.scalars().all()
+
+
+@router.patch(
+    "/config/personas/{persona_id}",
+    response_model=PersonaConfigOut,
+    dependencies=[Depends(verify_api_key)],
+)
+async def api_patch_persona_config(
+    persona_id: str,
+    body: PersonaConfigPatch,
+    session: AsyncSession = Depends(get_session),
+):
+    from opencompany.models.db import PersonaConfig
+
+    config = await session.get(PersonaConfig, persona_id)
+    if not config:
+        raise HTTPException(status_code=404, detail="PersonaConfig not found")
+    if body.instructions is not None:
+        config.instructions = body.instructions
+    if body.budget_tokens_daily is not None:
+        config.budget_tokens_daily = body.budget_tokens_daily
+    if body.personality is not None:
+        config.personality = body.personality
+    if body.skills is not None:
+        config.skills = body.skills
+    config.updated_by = "overseer"
+    await session.commit()
+    await session.refresh(config)
+    return config
+
+
+@router.post("/config/export", dependencies=[Depends(verify_api_key)])
+async def api_export_config(session: AsyncSession = Depends(get_session)):
+    """Dump current DB persona configs back to a timestamped YAML file."""
+    from datetime import UTC, datetime
+    from pathlib import Path
+
+    import yaml
+
+    from opencompany.models.db import PersonaConfig
+
+    result = await session.execute(select(PersonaConfig))
+    configs = result.scalars().all()
+
+    data = {
+        "personas": {
+            c.id: {
+                "name": c.name,
+                "role": c.role,
+                "trust": c.trust,
+                "skills": c.skills,
+                "budget_tokens_daily": c.budget_tokens_daily,
+                "instructions": c.instructions,
+                "personality": c.personality,
+            }
+            for c in configs
+        }
+    }
+    ts = datetime.now(UTC).strftime("%Y%m%d-%H%M")
+    out = Path(f"config/company-export-{ts}.yaml")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(yaml.dump(data, allow_unicode=True, sort_keys=False))
+    return {"exported_to": str(out)}
+
+
 # --- Efficiency metrics endpoint ---
 
 

--- a/src/opencompany/models/db.py
+++ b/src/opencompany/models/db.py
@@ -122,6 +122,41 @@ class PolicyDocument(Base):
     )
 
 
+class PersonaConfig(Base):
+    """Live editable config for a persona. Loaded by prompts.py at each run."""
+
+    __tablename__ = "persona_configs"
+
+    id: Mapped[str] = mapped_column(primary_key=True)  # matches personas.id
+    name: Mapped[str]
+    role: Mapped[str]
+    trust: Mapped[str] = mapped_column(default="solver")
+    skills: Mapped[list] = mapped_column(JSONB, default_factory=list)
+    budget_tokens_daily: Mapped[int] = mapped_column(default=0)
+    instructions: Mapped[str] = mapped_column(default="")
+    personality: Mapped[dict] = mapped_column(JSONB, default_factory=dict)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default_factory=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+    updated_by: Mapped[str] = mapped_column(default="system")
+
+
+class CompanySnapshot(Base):
+    """Append-only log of company state. Written on interval + task completion."""
+
+    __tablename__ = "company_snapshots"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False, autoincrement=True)
+    trigger: Mapped[str]  # interval | tasks_complete | manual
+    snapshot: Mapped[dict] = mapped_column(JSONB, default_factory=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default_factory=lambda: datetime.now(UTC),
+    )
+
+
 class OverseerMessage(Base):
     __tablename__ = "overseer_messages"
 

--- a/tests/test_sprint5_persona_config.py
+++ b/tests/test_sprint5_persona_config.py
@@ -1,0 +1,285 @@
+"""Tests for Sprint 5: P6 DB-backed persona config, snapshots, config API."""
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from opencompany.models.db import CompanySnapshot, PersonaConfig, Ticket
+
+
+@pytest.fixture
+async def factory(db_engine):
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+# ---------------------------------------------------------------------------
+# PersonaConfig model
+# ---------------------------------------------------------------------------
+class TestPersonaConfigModel:
+    async def test_create_persona_config(self, factory):
+        async with factory() as session:
+            pc = PersonaConfig(
+                id="dev-1",
+                name="Dev One",
+                role="developer",
+                trust="solver",
+                skills=["python", "backend"],
+                budget_tokens_daily=50000,
+                instructions="Write clean code.",
+                personality={"traits": ["focused"]},
+            )
+            session.add(pc)
+            await session.commit()
+            await session.refresh(pc)
+
+        async with factory() as session:
+            loaded = await session.get(PersonaConfig, "dev-1")
+            assert loaded.name == "Dev One"
+            assert loaded.trust == "solver"
+            assert loaded.skills == ["python", "backend"]
+            assert loaded.instructions == "Write clean code."
+            assert loaded.personality == {"traits": ["focused"]}
+
+    async def test_company_snapshot_model(self, factory):
+        async with factory() as session:
+            snap = CompanySnapshot(
+                trigger="manual",
+                snapshot={"personas": [], "tickets": {"open": 5}},
+            )
+            session.add(snap)
+            await session.commit()
+            await session.refresh(snap)
+
+        async with factory() as session:
+            from sqlalchemy import select
+
+            result = await session.execute(select(CompanySnapshot))
+            loaded = result.scalars().first()
+            assert loaded.trigger == "manual"
+            assert loaded.snapshot["tickets"]["open"] == 5
+
+
+# ---------------------------------------------------------------------------
+# boot_persona_configs
+# ---------------------------------------------------------------------------
+class TestBootPersonaConfigs:
+    async def test_boot_seeds_from_yaml(self, factory, tmp_path):
+        import yaml
+
+        yaml_file = tmp_path / "company.yaml"
+        yaml_file.write_text(
+            yaml.dump(
+                {
+                    "org_style": "hierarchical",
+                    "org_styles": {},
+                    "roles": {
+                        "ceo": {
+                            "type": "manager",
+                            "tag_match": ["strategy"],
+                            "daily_token_budget": 100000,
+                            "responsibilities": "Lead the company.",
+                            "personality": {"traits": ["bold"]},
+                        },
+                        "dev": {
+                            "type": "solver",
+                            "tag_match": ["backend"],
+                            "daily_token_budget": 50000,
+                            "responsibilities": "Write code.",
+                        },
+                    },
+                    "personas": {},
+                }
+            )
+        )
+
+        with patch("opencompany.models.engine.async_session", factory):
+            from opencompany.company.config import boot_persona_configs
+
+            count = await boot_persona_configs(str(yaml_file))
+
+        assert count == 2
+
+        async with factory() as session:
+            ceo = await session.get(PersonaConfig, "ceo")
+            assert ceo is not None
+            assert ceo.trust == "full"
+            assert ceo.budget_tokens_daily == 100000
+            assert ceo.personality == {"traits": ["bold"]}
+
+            dev = await session.get(PersonaConfig, "dev")
+            assert dev is not None
+            assert dev.trust == "solver"
+
+    async def test_boot_skips_if_already_seeded(self, factory):
+        async with factory() as session:
+            session.add(
+                PersonaConfig(
+                    id="existing",
+                    name="Existing",
+                    role="dev",
+                )
+            )
+            await session.commit()
+
+        with patch("opencompany.models.engine.async_session", factory):
+            from opencompany.company.config import boot_persona_configs
+
+            count = await boot_persona_configs()
+
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# snapshot_company
+# ---------------------------------------------------------------------------
+class TestSnapshotCompany:
+    async def test_snapshot_captures_state(self, factory):
+        async with factory() as session:
+            session.add(PersonaConfig(id="snap-dev", name="Snap Dev", role="dev"))
+            session.add(Ticket(title="Open task", tags=["x"], status="open"))
+            session.add(Ticket(title="Done task", tags=["x"], status="done"))
+            await session.commit()
+
+        with patch("opencompany.models.engine.async_session", factory):
+            from opencompany.company.scheduler import snapshot_company
+
+            await snapshot_company("test")
+
+        async with factory() as session:
+            from sqlalchemy import select
+
+            result = await session.execute(select(CompanySnapshot))
+            snap = result.scalars().first()
+            assert snap is not None
+            assert snap.trigger == "test"
+            assert len(snap.snapshot["personas"]) == 1
+            assert snap.snapshot["tickets"]["open"] == 1
+            assert snap.snapshot["tickets"]["done"] == 1
+
+    async def test_snapshot_skips_empty_config(self, factory):
+        """No PersonaConfigs → no snapshot written."""
+        with patch("opencompany.models.engine.async_session", factory):
+            from opencompany.company.scheduler import snapshot_company
+
+            await snapshot_company("test")
+
+        async with factory() as session:
+            from sqlalchemy import select
+
+            result = await session.execute(select(CompanySnapshot))
+            assert result.scalars().first() is None
+
+
+# ---------------------------------------------------------------------------
+# Config API endpoints
+# ---------------------------------------------------------------------------
+class TestConfigAPI:
+    async def test_list_persona_configs(self, db_engine):
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+        async with factory() as session:
+            session.add(
+                PersonaConfig(
+                    id="api-dev",
+                    name="API Dev",
+                    role="dev",
+                    instructions="Code well.",
+                )
+            )
+            await session.commit()
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from opencompany.gateway.api import router
+        from opencompany.models.engine import get_session
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+
+        async def override_session():
+            async with factory() as session:
+                yield session
+
+        app.dependency_overrides[get_session] = override_session
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/config/personas")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 1
+            assert data[0]["id"] == "api-dev"
+            assert data[0]["instructions"] == "Code well."
+
+    async def test_patch_persona_config(self, db_engine):
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+        async with factory() as session:
+            session.add(
+                PersonaConfig(
+                    id="patch-dev",
+                    name="Patch Dev",
+                    role="dev",
+                    instructions="Old instructions.",
+                    budget_tokens_daily=1000,
+                )
+            )
+            await session.commit()
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from opencompany.gateway.api import router
+        from opencompany.models.engine import get_session
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+
+        async def override_session():
+            async with factory() as session:
+                yield session
+
+        app.dependency_overrides[get_session] = override_session
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.patch(
+                "/api/config/personas/patch-dev",
+                json={
+                    "instructions": "New instructions.",
+                    "budget_tokens_daily": 5000,
+                },
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["instructions"] == "New instructions."
+            assert data["budget_tokens_daily"] == 5000
+            assert data["updated_by"] == "overseer"
+
+    async def test_patch_nonexistent_config(self, db_engine):
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from opencompany.gateway.api import router
+        from opencompany.models.engine import get_session
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+
+        async def override_session():
+            async with factory() as session:
+                yield session
+
+        app.dependency_overrides[get_session] = override_session
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.patch(
+                "/api/config/personas/ghost",
+                json={"instructions": "Nope."},
+            )
+            assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- **PersonaConfig** model: live editable config (instructions, personality, skills, budget) alongside existing Persona runtime model
- **CompanySnapshot** model: append-only log of org state (personas + ticket stats)
- `boot_persona_configs()`: seeds from company.yaml on first start, skips if DB has entries
- `snapshot_company()`: scheduled every 5min, captures full org state
- Config API: `GET /api/config/personas`, `PATCH /api/config/personas/{id}`, `POST /api/config/export`

## Test plan
- [x] 9 new tests covering models, boot seeding, snapshots, API endpoints
- [x] Zero regressions (376 passed)