### PR TITLE
feat: soul.md self-improvement system with validation gates

### DIFF
--- a/soul.md
+++ b/soul.md
@@ -1,0 +1,23 @@
+# Company Soul — Operating Principles
+# Version: 1
+
+## Core Rules
+
+1. **Ship working code, not perfect code.** Deliver incrementally. A functioning prototype beats a polished design doc.
+2. **Budget awareness.** Every persona must respect token budgets. If a task is too large, break it into sub-tasks rather than burning the full daily budget on one ticket.
+3. **Claim what you can handle.** Only pick up tickets that match your skills. If unsure, escalate rather than guess.
+4. **Review everything.** No ticket goes to done without a review. Reviewers should check for correctness, not style preferences.
+5. **Communicate blockers immediately.** If you're stuck, contact the overseer or escalate. Don't sit idle hoping the problem resolves itself.
+
+## Collaboration Rules
+
+6. **Respect the hierarchy.** Follow the org routing chain. Don't bypass your lead to assign work directly to solvers.
+7. **Don't over-hire.** HR should only hire when there's a genuine skill gap AND open work that can't be handled by existing team members.
+8. **Share findings.** Use publish_file to make work visible to others. Private workspace is for drafts; shared workspace is for deliverables.
+
+## Self-Improvement Rules
+
+9. **This document may be updated by the Company Analyst or lead+ personas.** Changes must pass validation gates.
+10. **No more than 3 rules may change per update.** Wholesale rewrites are rejected.
+11. **Protected rules cannot be removed:** rules 9, 10, 11, and 12 are immutable.
+12. **soul.md must not exceed 200 lines.** Role-specific detail belongs in SOP files, not here.

--- a/src/opencompany/agents/prompts.py
+++ b/src/opencompany/agents/prompts.py
@@ -45,6 +45,11 @@ def build_system_prompt(
     if policy_section:
         sections.append(policy_section)
 
+    # Inject soul.md operating principles (if available)
+    soul_section = _build_soul_section()
+    if soul_section:
+        sections.append(soul_section)
+
     if responsibilities:
         sections.append(f"\nRESPONSIBILITIES:\n{responsibilities}")
 
@@ -159,3 +164,17 @@ def _get_role_config(
             return config.roles[key]
 
     return {}
+
+
+def _build_soul_section() -> str:
+    """Read soul.md and format as a prompt section."""
+    try:
+        from opencompany.company.soul import read_soul
+
+        content = read_soul()
+        if not content:
+            return ""
+        return f"\nCOMPANY OPERATING PRINCIPLES:\n{content}"
+    except Exception:
+        logger.debug("Could not load soul.md", exc_info=True)
+        return ""

--- a/src/opencompany/company/soul.py
+++ b/src/opencompany/company/soul.py
@@ -1,0 +1,138 @@
+"""SoulManager: read, version, validate, apply, and rollback soul.md."""
+
+import difflib
+import logging
+import re
+from pathlib import Path
+
+from opencompany.models.engine import async_session
+
+logger = logging.getLogger(__name__)
+
+_SOUL_PATH = Path("soul.md")
+_MAX_LINES = 200
+_MAX_RULES_PER_UPDATE = 3
+_PROTECTED_PHRASES = [
+    "This document may be updated",
+    "No more than 3 rules may change",
+    "Protected rules cannot be removed",
+    "soul.md must not exceed 200 lines",
+]
+
+
+def read_soul() -> str:
+    """Read current soul.md content."""
+    if not _SOUL_PATH.exists():
+        return ""
+    return _SOUL_PATH.read_text()
+
+
+def _get_version_from_content(content: str) -> int:
+    """Extract version number from soul.md header."""
+    match = re.search(r"^# Version:\s*(\d+)", content, re.MULTILINE)
+    return int(match.group(1)) if match else 0
+
+
+def _count_rule_changes(old: str, new: str) -> int:
+    """Count number of rule lines that differ between old and new."""
+    old_rules = {line.strip() for line in old.splitlines() if re.match(r"^\d+\.\s", line.strip())}
+    new_rules = {line.strip() for line in new.splitlines() if re.match(r"^\d+\.\s", line.strip())}
+    return len(old_rules.symmetric_difference(new_rules))
+
+
+def _protected_rules_intact(new_content: str) -> bool:
+    """Check that all protected phrases are present in the new content."""
+    return all(phrase in new_content for phrase in _PROTECTED_PHRASES)
+
+
+def validate_soul_update(current: str, proposed: str) -> tuple[bool, str]:
+    """Validate a proposed soul.md update against safety gates.
+
+    Returns (valid, reason).
+    """
+    # Gate 1: version must be incremented
+    old_ver = _get_version_from_content(current)
+    new_ver = _get_version_from_content(proposed)
+    if new_ver <= old_ver:
+        return False, f"Version must be incremented (current={old_ver}, proposed={new_ver})"
+
+    # Gate 2: max rule changes
+    changes = _count_rule_changes(current, proposed)
+    if changes > _MAX_RULES_PER_UPDATE:
+        return False, f"Too many rule changes ({changes} > {_MAX_RULES_PER_UPDATE})"
+
+    # Gate 3: protected rules intact
+    if not _protected_rules_intact(proposed):
+        return False, "Protected rules must not be removed"
+
+    # Gate 4: line limit
+    lines = len(proposed.splitlines())
+    if lines > _MAX_LINES:
+        return False, f"soul.md exceeds {_MAX_LINES} lines ({lines})"
+
+    return True, "ok"
+
+
+async def propose_update(proposed: str, rationale: str, proposed_by: str) -> tuple[bool, str]:
+    """Propose a soul.md update. Validates, applies if valid, persists version.
+
+    Returns (accepted, reason).
+    """
+
+    from opencompany.models.db import SoulVersion
+
+    current = read_soul()
+    valid, reason = validate_soul_update(current, proposed)
+    if not valid:
+        logger.warning("Soul update rejected from %s: %s", proposed_by, reason)
+        return False, reason
+
+    # Generate diff
+    diff = "\n".join(
+        difflib.unified_diff(
+            current.splitlines(),
+            proposed.splitlines(),
+            fromfile="soul.md (old)",
+            tofile="soul.md (new)",
+            lineterm="",
+        )
+    )
+
+    # Apply
+    _SOUL_PATH.write_text(proposed)
+
+    # Persist version
+    new_ver = _get_version_from_content(proposed)
+    async with async_session() as session:
+        session.add(
+            SoulVersion(
+                version=new_ver,
+                content=proposed,
+                diff=diff,
+                rationale=rationale,
+                proposed_by=proposed_by,
+            )
+        )
+        await session.commit()
+
+    logger.info("Soul v%d applied (by %s): %s", new_ver, proposed_by, rationale)
+    return True, f"Soul v{new_ver} applied"
+
+
+async def rollback(target_version: int) -> tuple[bool, str]:
+    """Rollback soul.md to a specific version."""
+    from sqlalchemy import select
+
+    from opencompany.models.db import SoulVersion
+
+    async with async_session() as session:
+        result = await session.execute(
+            select(SoulVersion).where(SoulVersion.version == target_version)
+        )
+        sv = result.scalars().first()
+        if not sv:
+            return False, f"Version {target_version} not found"
+
+        _SOUL_PATH.write_text(sv.content)
+        logger.info("Soul rolled back to v%d", target_version)
+        return True, f"Rolled back to v{target_version}"

--- a/src/opencompany/models/db.py
+++ b/src/opencompany/models/db.py
@@ -157,6 +157,23 @@ class CompanySnapshot(Base):
     )
 
 
+class SoulVersion(Base):
+    """Append-only log of every accepted soul.md version."""
+
+    __tablename__ = "soul_versions"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False, autoincrement=True)
+    version: Mapped[int]
+    content: Mapped[str]
+    diff: Mapped[str] = mapped_column(default="")
+    rationale: Mapped[str] = mapped_column(default="")
+    proposed_by: Mapped[str] = mapped_column(default="system")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default_factory=lambda: datetime.now(UTC),
+    )
+
+
 class OverseerMessage(Base):
     __tablename__ = "overseer_messages"
 

--- a/tests/test_sprint6_soul.py
+++ b/tests/test_sprint6_soul.py
@@ -1,0 +1,244 @@
+"""Tests for Sprint 6: soul.md self-improvement system (SI1-SI3)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from opencompany.company.soul import (
+    _count_rule_changes,
+    _get_version_from_content,
+    _protected_rules_intact,
+    propose_update,
+    rollback,
+    validate_soul_update,
+)
+from opencompany.models.db import SoulVersion
+
+
+@pytest.fixture
+async def factory(db_engine):
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class TestSoulHelpers:
+    def test_get_version_from_content(self):
+        assert _get_version_from_content("# Version: 3\nstuff") == 3
+        assert _get_version_from_content("no version here") == 0
+
+    def test_count_rule_changes(self):
+        old = "1. Rule A\n2. Rule B\n3. Rule C"
+        new = "1. Rule A\n2. Rule B modified\n3. Rule C"
+        assert _count_rule_changes(old, new) == 2  # B changed (old B + new B)
+
+    def test_protected_rules_intact(self):
+        content = (
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n"
+        )
+        assert _protected_rules_intact(content) is True
+        assert _protected_rules_intact("missing stuff") is False
+
+
+# ---------------------------------------------------------------------------
+# Validation gates
+# ---------------------------------------------------------------------------
+class TestValidation:
+    def test_rejects_same_version(self):
+        current = "# Version: 1\n1. Rule A"
+        proposed = "# Version: 1\n1. Rule B"
+        valid, reason = validate_soul_update(current, proposed)
+        assert valid is False
+        assert "incremented" in reason
+
+    def test_rejects_too_many_changes(self):
+        current = "# Version: 1\n1. A\n2. B\n3. C\n4. D\n"
+        proposed = (
+            "# Version: 2\n1. X\n2. Y\n3. Z\n4. W\n"
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n"
+        )
+        valid, reason = validate_soul_update(current, proposed)
+        assert valid is False
+        assert "Too many" in reason
+
+    def test_rejects_missing_protected_rules(self):
+        current = (
+            "# Version: 1\n1. A\n"
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n"
+        )
+        proposed = "# Version: 2\n1. A modified\n"
+        valid, reason = validate_soul_update(current, proposed)
+        assert valid is False
+        assert "Protected" in reason
+
+    def test_rejects_too_many_lines(self):
+        current = "# Version: 1\n1. A\n"
+        proposed = (
+            "# Version: 2\n1. A modified\n"
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n" + "\n".join(f"Line {i}" for i in range(200))
+        )
+        valid, reason = validate_soul_update(current, proposed)
+        assert valid is False
+        assert "200 lines" in reason
+
+    def test_accepts_valid_update(self):
+        current = (
+            "# Version: 1\n1. Old rule\n"
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n"
+        )
+        proposed = (
+            "# Version: 2\n1. New rule\n"
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n"
+        )
+        valid, reason = validate_soul_update(current, proposed)
+        assert valid is True
+
+
+# ---------------------------------------------------------------------------
+# propose_update + rollback
+# ---------------------------------------------------------------------------
+class TestProposeAndRollback:
+    async def test_propose_valid_update(self, factory, tmp_path):
+        soul_file = tmp_path / "soul.md"
+        current = (
+            "# Version: 1\n1. Old rule\n"
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n"
+        )
+        soul_file.write_text(current)
+
+        proposed = (
+            "# Version: 2\n1. New rule\n"
+            "This document may be updated\n"
+            "No more than 3 rules may change\n"
+            "Protected rules cannot be removed\n"
+            "soul.md must not exceed 200 lines\n"
+        )
+
+        with (
+            patch("opencompany.company.soul._SOUL_PATH", soul_file),
+            patch("opencompany.company.soul.async_session", factory),
+        ):
+            accepted, reason = await propose_update(proposed, "Modernize rules", "company-analyst")
+
+        assert accepted is True
+        assert "v2" in reason
+        assert soul_file.read_text() == proposed
+
+        # Check DB has the version
+        async with factory() as session:
+            result = await session.execute(select(SoulVersion))
+            sv = result.scalars().first()
+            assert sv.version == 2
+            assert sv.proposed_by == "company-analyst"
+
+    async def test_propose_invalid_rejected(self, factory, tmp_path):
+        soul_file = tmp_path / "soul.md"
+        soul_file.write_text("# Version: 1\n1. Rule\n")
+
+        with (
+            patch("opencompany.company.soul._SOUL_PATH", soul_file),
+            patch("opencompany.company.soul.async_session", factory),
+        ):
+            accepted, reason = await propose_update(
+                "# Version: 1\n1. Same version\n",  # no version bump
+                "Bad update",
+                "rogue-agent",
+            )
+
+        assert accepted is False
+        assert "incremented" in reason
+
+    async def test_rollback_to_version(self, factory, tmp_path):
+        soul_file = tmp_path / "soul.md"
+        soul_file.write_text("# Version: 2\nCurrent content")
+
+        # Seed a v1 in the DB
+        async with factory() as session:
+            session.add(
+                SoulVersion(
+                    version=1,
+                    content="# Version: 1\nOriginal content",
+                    proposed_by="system",
+                )
+            )
+            await session.commit()
+
+        with (
+            patch("opencompany.company.soul._SOUL_PATH", soul_file),
+            patch("opencompany.company.soul.async_session", factory),
+        ):
+            ok, msg = await rollback(1)
+
+        assert ok is True
+        assert soul_file.read_text() == "# Version: 1\nOriginal content"
+
+    async def test_rollback_nonexistent_version(self, factory):
+        with patch("opencompany.company.soul.async_session", factory):
+            ok, msg = await rollback(999)
+
+        assert ok is False
+        assert "not found" in msg
+
+
+# ---------------------------------------------------------------------------
+# Soul injection into prompts
+# ---------------------------------------------------------------------------
+class TestSoulPromptInjection:
+    def test_soul_injected_into_prompt(self, tmp_path):
+        soul_file = tmp_path / "soul.md"
+        soul_file.write_text("# Company Soul\n1. Be excellent.")
+
+        persona = MagicMock()
+        persona.id = "dev-1"
+        persona.name = "Dev"
+        persona.role = "Developer"
+        persona.type = "solver"
+        persona.skills = ["python"]
+        persona.tools = ["read_file"]
+        persona.backstory = "A developer."
+
+        with (
+            patch("opencompany.company.soul._SOUL_PATH", soul_file),
+            patch(
+                "opencompany.agents.prompts._get_role_config",
+                return_value={},
+            ),
+            patch(
+                "opencompany.agents.prompts._build_personality_section",
+                return_value="",
+            ),
+            patch(
+                "opencompany.agents.prompts._build_policy_section",
+                return_value="",
+            ),
+        ):
+            from opencompany.agents.prompts import build_system_prompt
+
+            prompt = build_system_prompt(persona)
+
+        assert "COMPANY OPERATING PRINCIPLES" in prompt
+        assert "Be excellent" in prompt


### PR DESCRIPTION
## Summary

- **soul.md**: Living operating principles (12 rules, version 1) read by every persona at task start
- **SoulVersion** model: append-only log of every accepted soul.md version with diffs
- **SoulManager** (`company/soul.py`): `propose_update()` with 4 validation gates, `rollback()`
- **Prompt injection**: soul.md content injected into every persona's system prompt

### Validation gates
1. Version must be incremented
2. ≤3 rule changes per update
3. Protected rules (self-improvement rules 9-12) cannot be removed
4. ≤200 lines total

## Test plan
- [x] 13 new tests covering helpers, validation, propose/rollback, prompt injection
- [x] Zero regressions (389 passed)