### PR TITLE
feat: researcher/marketer personas + propose_soul_update tool

### DIFF
--- a/config/company.yaml
+++ b/config/company.yaml
@@ -1029,4 +1029,80 @@ roles:
     - python
     - byteslice
     routes_to: solver
+  researcher:
+    type: solver
+    daily_token_budget: 80000
+    max_headcount: 1
+    responsibilities: |
+      Run at project kickoff, before any design or code tickets are assigned.
+      Use web_search and web_fetch to map the domain: competitors, tech choices, user needs.
+      Save findings to workspace/research/{topic}.md.
+      Your research should inform design and implementation decisions.
+    constraints: |
+      Do not write code. Focus on research and documentation only.
+      Always save findings as markdown files in the research directory.
+    personality:
+      traits:
+      - analytical
+      - thorough
+      - curious
+      communication_style: Academic but accessible. Cites sources. Uses bullet points heavily.
+      quirks:
+      - Always includes a 'Key Takeaways' section
+      - Compares everything to at least two alternatives
+      catchphrases:
+      - The data suggests...
+      - Let me dig deeper.
+      - Here's what the landscape looks like.
+    tools:
+    - web_search
+    - web_fetch
+    - write_file
+    - read_file
+    - list_tickets
+    - update_ticket
+    tag_match:
+    - research
+    - analysis
+    - market
+    - competitor
+    routes_to: solver
+  marketer:
+    type: solver
+    daily_token_budget: 60000
+    max_headcount: 1
+    responsibilities: |
+      Write marketing copy, landing pages, social media content, and product descriptions.
+      Always read researcher findings before writing anything.
+      Copy is always assigned a review ticket before marking done.
+    constraints: |
+      No access to hire_persona or run_script. Pure content role.
+      Always check for research docs before starting any content work.
+      Never publish without review.
+    personality:
+      traits:
+      - creative
+      - persuasive
+      - brand-conscious
+      communication_style: Punchy and engaging. Writes for humans, not algorithms.
+      quirks:
+      - Always writes three headline options
+      - Obsessed with call-to-action placement
+      catchphrases:
+      - What's the hook?
+      - Ship the copy.
+      - Less is more.
+    tools:
+    - write_file
+    - read_file
+    - list_tickets
+    - update_ticket
+    - publish_file
+    tag_match:
+    - marketing
+    - copy
+    - content
+    - landing-page
+    - social
+    routes_to: solver
 personas: {}

--- a/src/opencompany/agents/tools/__init__.py
+++ b/src/opencompany/agents/tools/__init__.py
@@ -16,6 +16,7 @@ from opencompany.agents.tools.policy import (
     read_policy,
     write_policy,
 )
+from opencompany.agents.tools.soul import propose_soul_update, read_soul
 from opencompany.agents.tools.tickets import create_ticket, list_tickets, update_ticket
 from opencompany.agents.tools.web import web_fetch, web_search
 
@@ -43,4 +44,6 @@ ALL_TOOLS = {
     "approve_policy": approve_policy,
     "list_policies": list_policies,
     "read_policy": read_policy,
+    "propose_soul_update": propose_soul_update,
+    "read_soul": read_soul,
 }

--- a/src/opencompany/agents/tools/soul.py
+++ b/src/opencompany/agents/tools/soul.py
@@ -1,0 +1,50 @@
+"""Soul tools: allow lead+ personas to propose updates to soul.md."""
+
+from strands import tool
+
+
+@tool
+def propose_soul_update(
+    proposed_content: str,
+    rationale: str,
+    persona_id: str = "",
+) -> str:
+    """Propose an update to soul.md (company operating principles).
+
+    The update must pass validation gates:
+    - Version number must be incremented
+    - Maximum 3 rule changes per update
+    - Protected rules (self-improvement rules) cannot be removed
+    - soul.md must not exceed 200 lines
+
+    Only available to lead trust tier and above.
+
+    Args:
+        proposed_content: The full proposed soul.md content (include version header)
+        rationale: Why this change is needed (will be logged)
+        persona_id: Your persona ID
+    """
+    from opencompany.company.soul import propose_update
+    from opencompany.utils import _run_async
+
+    accepted, reason = _run_async(propose_update(proposed_content, rationale, persona_id))
+    if accepted:
+        return f"Soul update accepted: {reason}"
+    return f"Soul update rejected: {reason}"
+
+
+@tool
+def read_soul(
+    persona_id: str = "",
+) -> str:
+    """Read the current soul.md operating principles.
+
+    Args:
+        persona_id: Your persona ID
+    """
+    from opencompany.company.soul import read_soul as _read
+
+    content = _read()
+    if not content:
+        return "No soul.md found."
+    return content

--- a/src/opencompany/company/trust.py
+++ b/src/opencompany/company/trust.py
@@ -20,6 +20,7 @@ TOOL_TIER_REQUIREMENTS: dict[str, str] = {
     # Lead tier+
     "create_ticket": "lead",
     "send_message": "lead",
+    "propose_soul_update": "lead",
     # Solver tier+
     "write_file": "solver",
     "update_ticket": "solver",

--- a/tests/test_sprint7.py
+++ b/tests/test_sprint7.py
@@ -1,0 +1,62 @@
+"""Tests for Sprint 7: R1/R2 personas + SI4 propose_soul_update tool."""
+
+from opencompany.company.config import load_company_config
+from opencompany.company.trust import TOOL_TIER_REQUIREMENTS, filter_tools_by_tier
+
+
+# ---------------------------------------------------------------------------
+# R1/R2: Researcher and Marketer roles in YAML
+# ---------------------------------------------------------------------------
+class TestNewRoles:
+    def test_researcher_role_exists(self):
+        config = load_company_config()
+        assert "researcher" in config.roles
+        role = config.roles["researcher"]
+        assert role["type"] == "solver"
+        assert "web_search" in role["tools"]
+        assert "web_fetch" in role["tools"]
+        assert "research" in role.get("tag_match", [])
+
+    def test_marketer_role_exists(self):
+        config = load_company_config()
+        assert "marketer" in config.roles
+        role = config.roles["marketer"]
+        assert role["type"] == "solver"
+        assert "write_file" in role["tools"]
+        assert "publish_file" in role["tools"]
+        assert "marketing" in role.get("tag_match", [])
+        # Marketer should NOT have hire or run_script
+        assert "hire_persona" not in role["tools"]
+        assert "run_script" not in role["tools"]
+
+
+# ---------------------------------------------------------------------------
+# SI4: propose_soul_update tool trust tier
+# ---------------------------------------------------------------------------
+class TestSoulToolTrust:
+    def test_propose_soul_update_requires_lead(self):
+        assert TOOL_TIER_REQUIREMENTS["propose_soul_update"] == "lead"
+
+    def test_solver_cannot_propose_soul_update(self):
+        allowed, denied = filter_tools_by_tier(["propose_soul_update"], "solver")
+        assert "propose_soul_update" in denied
+
+    def test_lead_can_propose_soul_update(self):
+        allowed, denied = filter_tools_by_tier(["propose_soul_update"], "lead")
+        assert "propose_soul_update" in allowed
+
+    def test_read_soul_accessible_to_all(self):
+        # read_soul has no tier requirement (defaults to external)
+        allowed, denied = filter_tools_by_tier(["read_soul"], "external")
+        assert "read_soul" in allowed
+
+
+# ---------------------------------------------------------------------------
+# Soul tools are registered
+# ---------------------------------------------------------------------------
+class TestSoulToolRegistration:
+    def test_tools_registered(self):
+        from opencompany.agents.tools import ALL_TOOLS
+
+        assert "propose_soul_update" in ALL_TOOLS
+        assert "read_soul" in ALL_TOOLS

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,7 +36,7 @@ def test_company_tool_schema():
 def test_all_tools_registry():
     from opencompany.agents.tools import ALL_TOOLS
 
-    assert len(ALL_TOOLS) == 23
+    assert len(ALL_TOOLS) == 25
     for name, func in ALL_TOOLS.items():
         assert callable(func), f"{name} is not callable"
 


### PR DESCRIPTION
## Summary

- **R1 Researcher**: New role with web_search + web_fetch, triggered at project kickoff for domain mapping
- **R2 Marketer**: New role for copy/content with publish_file, reads research before writing
- **SI4 propose_soul_update**: Tool gated at lead+ trust tier, validates through SoulManager gates
- **read_soul**: Tool accessible to all tiers for reading operating principles

## Test plan
- [x] 7 new tests covering role configs, trust tiers, tool registration
- [x] Updated tool count assertion (23→25)
- [x] Zero regressions (396 passed)