### PR TITLE
feat: SI5 soul history API + S5 OpenTelemetry entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,18 @@ COPY --chown=appuser:appuser alembic.ini ./
 COPY --chown=appuser:appuser src/ src/
 COPY --chown=appuser:appuser config/ config/
 COPY --chown=appuser:appuser migrations/ migrations/
+COPY --chown=appuser:appuser soul.md ./
+COPY --chown=appuser:appuser sops/ sops/
 
 # Persistent workspace volume — agent working directories
 RUN mkdir -p workspaces && chown appuser:appuser workspaces
 VOLUME ["/app/workspaces"]
+
+# OpenTelemetry: set OTEL_ENABLED=true to wrap uvicorn with OTEL auto-instrumentation
+# Requires opentelemetry-distro + opentelemetry-exporter-otlp in dependencies
+ENV OTEL_ENABLED=false \
+    OTEL_SERVICE_NAME=opencompany \
+    OTEL_EXPORTER_OTLP_ENDPOINT=""
 
 USER appuser
 
@@ -50,4 +58,7 @@ USER appuser
 HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-CMD ["uvicorn", "opencompany.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Use entrypoint script to conditionally wrap with OTEL
+COPY --chown=appuser:appuser docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Conditionally wrap uvicorn with OpenTelemetry auto-instrumentation.
+# Set OTEL_ENABLED=true and OTEL_EXPORTER_OTLP_ENDPOINT to enable tracing.
+
+if [ "$OTEL_ENABLED" = "true" ]; then
+    echo "OpenTelemetry enabled: service=$OTEL_SERVICE_NAME endpoint=$OTEL_EXPORTER_OTLP_ENDPOINT"
+    exec opentelemetry-instrument uvicorn opencompany.main:app --host 0.0.0.0 --port 8000
+else
+    exec uvicorn opencompany.main:app --host 0.0.0.0 --port 8000
+fi

--- a/src/opencompany/gateway/api.py
+++ b/src/opencompany/gateway/api.py
@@ -335,6 +335,52 @@ async def api_export_config(session: AsyncSession = Depends(get_session)):
     return {"exported_to": str(out)}
 
 
+# --- Soul history endpoints ---
+
+
+@router.get("/soul", dependencies=[Depends(verify_api_key)])
+async def api_get_soul():
+    """Return current soul.md content."""
+    from opencompany.company.soul import read_soul
+
+    return {"content": read_soul()}
+
+
+@router.get("/soul/history", dependencies=[Depends(verify_api_key)])
+async def api_soul_history(
+    limit: int = 10,
+    session: AsyncSession = Depends(get_session),
+):
+    """Return recent soul.md version history with diffs."""
+    from opencompany.models.db import SoulVersion
+
+    result = await session.execute(
+        select(SoulVersion).order_by(SoulVersion.version.desc()).limit(limit)
+    )
+    versions = result.scalars().all()
+    return [
+        {
+            "version": v.version,
+            "proposed_by": v.proposed_by,
+            "rationale": v.rationale,
+            "diff": v.diff,
+            "created_at": v.created_at.isoformat() if v.created_at else None,
+        }
+        for v in versions
+    ]
+
+
+@router.post("/soul/rollback/{version}", dependencies=[Depends(verify_api_key)])
+async def api_soul_rollback(version: int):
+    """Rollback soul.md to a specific version."""
+    from opencompany.company.soul import rollback
+
+    ok, msg = await rollback(version)
+    if not ok:
+        raise HTTPException(status_code=404, detail=msg)
+    return {"status": "ok", "message": msg}
+
+
 # --- Efficiency metrics endpoint ---
 
 

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -1,0 +1,154 @@
+"""Tests for Sprint 10: SI5 soul history API + S5 OTEL config."""
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from opencompany.models.db import SoulVersion
+
+
+@pytest.fixture
+async def factory(db_engine):
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+# ---------------------------------------------------------------------------
+# SI5: Soul history API
+# ---------------------------------------------------------------------------
+class TestSoulAPI:
+    async def test_get_soul(self, db_engine, tmp_path):
+        soul_file = tmp_path / "soul.md"
+        soul_file.write_text("# Test Soul\n1. Be good.")
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from opencompany.gateway.api import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+
+        with patch("opencompany.company.soul._SOUL_PATH", soul_file):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/api/soul")
+                assert resp.status_code == 200
+                assert "Be good" in resp.json()["content"]
+
+    async def test_soul_history(self, db_engine):
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+        async with factory() as session:
+            session.add(
+                SoulVersion(
+                    version=1,
+                    content="v1 content",
+                    diff="",
+                    rationale="Initial",
+                    proposed_by="system",
+                )
+            )
+            session.add(
+                SoulVersion(
+                    version=2,
+                    content="v2 content",
+                    diff="+new rule",
+                    rationale="Improvement",
+                    proposed_by="analyst",
+                )
+            )
+            await session.commit()
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from opencompany.gateway.api import router
+        from opencompany.models.engine import get_session
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+
+        async def override_session():
+            async with factory() as session:
+                yield session
+
+        app.dependency_overrides[get_session] = override_session
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/soul/history")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 2
+            # Most recent first
+            assert data[0]["version"] == 2
+            assert data[0]["proposed_by"] == "analyst"
+            assert data[1]["version"] == 1
+
+    async def test_soul_rollback_api(self, db_engine, tmp_path):
+        factory = async_sessionmaker(db_engine, expire_on_commit=False)
+        soul_file = tmp_path / "soul.md"
+        soul_file.write_text("# Version: 2\nCurrent")
+
+        async with factory() as session:
+            session.add(
+                SoulVersion(
+                    version=1,
+                    content="# Version: 1\nOriginal",
+                    proposed_by="system",
+                )
+            )
+            await session.commit()
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from opencompany.gateway.api import router
+        from opencompany.models.engine import get_session
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+
+        async def override_session():
+            async with factory() as session:
+                yield session
+
+        app.dependency_overrides[get_session] = override_session
+
+        with (
+            patch("opencompany.company.soul._SOUL_PATH", soul_file),
+            patch("opencompany.company.soul.async_session", factory),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/soul/rollback/1")
+                assert resp.status_code == 200
+                assert "v1" in resp.json()["message"]
+
+        assert "Original" in soul_file.read_text()
+
+
+# ---------------------------------------------------------------------------
+# S5: OpenTelemetry entrypoint
+# ---------------------------------------------------------------------------
+class TestOTELConfig:
+    def test_entrypoint_script_exists(self):
+        from pathlib import Path
+
+        assert Path("docker-entrypoint.sh").exists()
+
+    def test_entrypoint_has_otel_toggle(self):
+        from pathlib import Path
+
+        content = Path("docker-entrypoint.sh").read_text()
+        assert "OTEL_ENABLED" in content
+        assert "opentelemetry-instrument" in content
+
+    def test_dockerfile_copies_soul_and_sops(self):
+        from pathlib import Path
+
+        content = Path("Dockerfile").read_text()
+        assert "soul.md" in content
+        assert "sops/" in content
+        assert "OTEL_SERVICE_NAME" in content


### PR DESCRIPTION
## Summary

- **SI5**: Soul history API — `GET /api/soul` (current content), `GET /api/soul/history` (version log with diffs), `POST /api/soul/rollback/{version}`
- **S5**: OpenTelemetry entrypoint — `docker-entrypoint.sh` with `OTEL_ENABLED` toggle for conditional auto-instrumentation. Dockerfile updated to copy `soul.md` and `sops/`.

## Test plan
- [x] 6 new tests covering soul API endpoints, entrypoint script, Dockerfile contents
- [x] Zero regressions (418 passed)