### PR TITLE
feat: S4 Redis session manager for persona conversation history

### DIFF
--- a/src/opencompany/agents/session.py
+++ b/src/opencompany/agents/session.py
@@ -1,0 +1,102 @@
+"""Redis-backed session manager for persona conversation history.
+
+Stores conversation context per persona in Redis, surviving container
+restarts without requiring the custom PersonaMemory table. Works with
+the existing Redis sidecar.
+
+Usage in runner.py:
+    session_mgr = get_session_manager()
+    # Before creating agent: load prior context
+    history = await session_mgr.load(persona_id)
+    # After agent run: save updated context
+    await session_mgr.save(persona_id, messages)
+"""
+
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_SESSION_TTL = int(os.environ.get("SESSION_TTL_SECONDS", str(86400 * 7)))  # 7 days
+_KEY_PREFIX = "opencompany:session:"
+
+
+class RedisSessionManager:
+    """Lightweight session manager using Redis for persona conversation history."""
+
+    def __init__(self, ttl: int = _SESSION_TTL):
+        self.ttl = ttl
+
+    def _key(self, persona_id: str) -> str:
+        return f"{_KEY_PREFIX}{persona_id}"
+
+    async def load(self, persona_id: str) -> list[dict]:
+        """Load conversation history for a persona from Redis.
+
+        Returns a list of message dicts (role, content) or empty list.
+        """
+        try:
+            from opencompany.events.bus import get_redis
+
+            r = await get_redis()
+            data = await r.get(self._key(persona_id))
+            if data:
+                messages = json.loads(data)
+                logger.debug(
+                    "Loaded %d messages for persona %s",
+                    len(messages),
+                    persona_id,
+                )
+                return messages
+        except Exception:
+            logger.debug("Could not load session for %s", persona_id, exc_info=True)
+        return []
+
+    async def save(self, persona_id: str, messages: list[dict]) -> None:
+        """Save conversation history for a persona to Redis.
+
+        Truncates to the most recent 50 messages to prevent unbounded growth.
+        """
+        try:
+            from opencompany.events.bus import get_redis
+
+            # Keep only recent messages
+            truncated = messages[-50:] if len(messages) > 50 else messages
+            r = await get_redis()
+            await r.set(
+                self._key(persona_id),
+                json.dumps(truncated),
+                ex=self.ttl,
+            )
+            logger.debug(
+                "Saved %d messages for persona %s (ttl=%ds)",
+                len(truncated),
+                persona_id,
+                self.ttl,
+            )
+        except Exception:
+            logger.debug("Could not save session for %s", persona_id, exc_info=True)
+
+    async def clear(self, persona_id: str) -> None:
+        """Clear conversation history for a persona."""
+        try:
+            from opencompany.events.bus import get_redis
+
+            r = await get_redis()
+            await r.delete(self._key(persona_id))
+            logger.info("Cleared session for persona %s", persona_id)
+        except Exception:
+            logger.debug("Could not clear session for %s", persona_id, exc_info=True)
+
+
+# Module-level singleton
+_session_manager: RedisSessionManager | None = None
+
+
+def get_session_manager() -> RedisSessionManager:
+    """Get or create the global session manager."""
+    global _session_manager
+    if _session_manager is None:
+        _session_manager = RedisSessionManager()
+    return _session_manager

--- a/tests/test_sprint11_session.py
+++ b/tests/test_sprint11_session.py
@@ -1,0 +1,127 @@
+"""Tests for Sprint 11: S4 Redis session manager for persona memory."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from opencompany.agents.session import RedisSessionManager, get_session_manager
+
+
+class TestRedisSessionManager:
+    async def test_save_and_load(self):
+        """Save messages, then load them back."""
+        mock_redis = AsyncMock()
+        stored = {}
+
+        async def mock_set(key, value, ex=None):
+            stored[key] = value
+
+        async def mock_get(key):
+            return stored.get(key)
+
+        mock_redis.set = mock_set
+        mock_redis.get = mock_get
+
+        with patch(
+            "opencompany.events.bus.get_redis",
+            new_callable=AsyncMock,
+            return_value=mock_redis,
+        ):
+            mgr = RedisSessionManager(ttl=3600)
+            messages = [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ]
+
+            await mgr.save("dev-1", messages)
+            loaded = await mgr.load("dev-1")
+
+        assert len(loaded) == 2
+        assert loaded[0]["content"] == "Hello"
+        assert loaded[1]["content"] == "Hi there!"
+
+    async def test_load_empty_when_no_session(self):
+        """Load returns empty list when no session exists."""
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+
+        with patch(
+            "opencompany.events.bus.get_redis",
+            new_callable=AsyncMock,
+            return_value=mock_redis,
+        ):
+            mgr = RedisSessionManager()
+            loaded = await mgr.load("nonexistent")
+
+        assert loaded == []
+
+    async def test_save_truncates_to_50(self):
+        """Save keeps only the most recent 50 messages."""
+        mock_redis = AsyncMock()
+        saved_data = {}
+
+        async def mock_set(key, value, ex=None):
+            saved_data[key] = value
+
+        mock_redis.set = mock_set
+
+        with patch(
+            "opencompany.events.bus.get_redis",
+            new_callable=AsyncMock,
+            return_value=mock_redis,
+        ):
+            mgr = RedisSessionManager()
+            messages = [{"role": "user", "content": f"msg {i}"} for i in range(100)]
+            await mgr.save("dev-1", messages)
+
+        stored = json.loads(saved_data["opencompany:session:dev-1"])
+        assert len(stored) == 50
+        assert stored[0]["content"] == "msg 50"  # kept the last 50
+
+    async def test_clear(self):
+        """Clear deletes the session key."""
+        mock_redis = AsyncMock()
+        mock_redis.delete = AsyncMock()
+
+        with patch(
+            "opencompany.events.bus.get_redis",
+            new_callable=AsyncMock,
+            return_value=mock_redis,
+        ):
+            mgr = RedisSessionManager()
+            await mgr.clear("dev-1")
+
+        mock_redis.delete.assert_awaited_once_with("opencompany:session:dev-1")
+
+    async def test_load_handles_redis_error(self):
+        """Load returns empty list when Redis is unavailable."""
+        with patch(
+            "opencompany.events.bus.get_redis",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("Redis down"),
+        ):
+            mgr = RedisSessionManager()
+            loaded = await mgr.load("dev-1")
+
+        assert loaded == []
+
+    async def test_save_handles_redis_error(self):
+        """Save fails silently when Redis is unavailable."""
+        with patch(
+            "opencompany.events.bus.get_redis",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("Redis down"),
+        ):
+            mgr = RedisSessionManager()
+            # Should not raise
+            await mgr.save("dev-1", [{"role": "user", "content": "test"}])
+
+
+class TestGetSessionManager:
+    def test_returns_singleton(self):
+        from opencompany.agents import session
+
+        session._session_manager = None
+        mgr1 = get_session_manager()
+        mgr2 = get_session_manager()
+        assert mgr1 is mgr2
+        session._session_manager = None  # cleanup


### PR DESCRIPTION
## Summary

- **RedisSessionManager**: Stores per-persona conversation context in the existing Redis sidecar
- Survives container restarts automatically (no custom PersonaMemory tools needed)
- Truncates to 50 most recent messages to prevent unbounded growth
- Configurable TTL via `SESSION_TTL_SECONDS` (default 7 days)
- Fails silently when Redis unavailable — graceful degradation

## Test plan
- [x] 7 new tests covering save/load, truncation, clear, error handling, singleton
- [x] Zero regressions (425 passed)