### PR TITLE
fix(engine): load fairness — stop one persona hogging the queue

### DIFF
--- a/src/opencompany/agents/tools/company.py
+++ b/src/opencompany/agents/tools/company.py
@@ -30,7 +30,24 @@ def hire_persona(
         tools: Comma-separated tool names (optional, e.g. "read_file,write_file")
         picks_up: Comma-separated tags this persona picks up (optional)
     """
+    from opencompany.agents.hooks import HiringGuardrail
     from opencompany.company.personas import hire_persona_sync
+    from opencompany.utils import _run_async
+
+    # Guardrail: check capacity before attempting the hire. This returns a
+    # steering message (not a hard error) when the team already has enough
+    # capacity — the agent sees corrective context instead of a cryptic
+    # rejection, so they can redirect to assigning an existing team member.
+    # ``_hire_persona`` still hard-blocks on the same check as defense-in-depth.
+    steering = _run_async(
+        HiringGuardrail().check_hire(
+            "hire_persona",
+            {"persona_id": persona_id, "name": name, "role": role},
+        )
+    )
+    if steering:
+        logger.info("[tool] hire_persona: guardrail blocked hire of %s (%s)", persona_id, role)
+        return steering
 
     skill_list = [s.strip() for s in skills.split(",") if s.strip()]
     tool_list = [t.strip() for t in tools.split(",") if t.strip()] if tools else None
@@ -110,7 +127,13 @@ def fire_persona(persona_id: str, reason: str = "") -> str:
 
 @tool
 def list_team(reports_to: str = "") -> str:
-    """List active personas in the company.
+    """List active personas in the company with workload and budget signals.
+
+    The output includes workload (open ticket count), ``tokens_used_today``
+    vs ``daily_token_budget``, and ``activity_state`` so the caller can make
+    informed hire/reassign/consolidate decisions. Use this BEFORE deciding
+    to hire — if an existing team member already covers the needed role,
+    assign the work to them instead of growing headcount.
 
     Args:
         reports_to: Filter by manager ID (optional, empty = all)
@@ -120,5 +143,20 @@ def list_team(reports_to: str = "") -> str:
     personas = list_personas_sync(reports_to=reports_to or None)
     if not personas:
         return "No active personas found"
-    lines = [f"- {p['name']} ({p['role']}) [{p['type']}] skills={p['skills']}" for p in personas]
+
+    lines = []
+    for p in personas:
+        budget = p.get("daily_token_budget") or 0
+        used = p.get("tokens_used_today") or 0
+        if budget > 0:
+            budget_str = f"tokens={used}/{budget} ({int(used / budget * 100)}%)"
+        else:
+            budget_str = f"tokens={used} (unlimited)"
+        lines.append(
+            f"- {p['name']} ({p['role']}) [{p['type']}] "
+            f"state={p.get('activity_state', 'unknown')} "
+            f"workload={p.get('workload', 0)} "
+            f"{budget_str} "
+            f"skills={p['skills']}"
+        )
     return "\n".join(lines)

--- a/src/opencompany/company/personas.py
+++ b/src/opencompany/company/personas.py
@@ -280,14 +280,42 @@ def fire_persona_sync(**kwargs) -> str:
 
 
 async def _list_personas(reports_to: str | None = None) -> list[dict]:
+    """List active personas with workload and budget signals.
+
+    The return shape deliberately includes load signals (``workload``,
+    ``tokens_used_today``, ``daily_token_budget``, ``activity_state``) so that
+    LLM agents calling ``list_team`` can make informed hire/reassign decisions
+    rather than guessing from name+role alone. ``workload`` counts tickets the
+    persona currently holds in ``assigned`` or ``in_progress`` states.
+    """
     async with async_session() as session:
         q = select(Persona).where(Persona.status == "active")
         if reports_to:
             q = q.where(Persona.reports_to == reports_to)
-        result = await session.execute(q)
+        rows = (await session.execute(q)).scalars().all()
+
+        # Single aggregated query for per-persona workload — avoid N+1.
+        workload_stmt = (
+            select(Ticket.assigned_to, func.count(Ticket.id))
+            .where(Ticket.status.in_(("assigned", "in_progress")))
+            .group_by(Ticket.assigned_to)
+        )
+        workload_rows = (await session.execute(workload_stmt)).all()
+        workload_by_id: dict[str, int] = {pid: count for pid, count in workload_rows if pid}
+
         personas = [
-            {"id": p.id, "name": p.name, "role": p.role, "type": p.type, "skills": p.skills}
-            for p in result.scalars().all()
+            {
+                "id": p.id,
+                "name": p.name,
+                "role": p.role,
+                "type": p.type,
+                "skills": p.skills,
+                "activity_state": p.activity_state,
+                "workload": workload_by_id.get(p.id, 0),
+                "tokens_used_today": p.tokens_used_today or 0,
+                "daily_token_budget": p.daily_token_budget or 0,
+            }
+            for p in rows
         ]
         logger.debug("Listed %d active personas (reports_to=%s)", len(personas), reports_to)
         return personas

--- a/src/opencompany/company/taskboard.py
+++ b/src/opencompany/company/taskboard.py
@@ -2,6 +2,7 @@
 
 import logging
 import random
+from collections.abc import Sequence
 from datetime import UTC, datetime
 
 from sqlalchemy import select, update
@@ -15,22 +16,44 @@ logger = logging.getLogger(__name__)
 
 
 def _fuzzy_tag_score(solver_tags: set[str], ticket_tags: set[str]) -> float:
-    """Score a solver against ticket tags using exact + substring matching.
+    """Score a solver against ticket tags using exact + length-weighted substring.
 
-    Exact match = 1.0 per tag, substring match = 0.5 per tag.
-    E.g. solver skill "frontend" partially matches ticket tag "frontend-dev",
-    and "design" partially matches "web-design".
+    - Exact match: ``1.0`` per ticket tag.
+    - Substring match: ``0.5 × (shorter_len / longer_len)``, taking the best
+      partial across all solver tags (not summed — one ticket tag, one
+      partial credit).
+
+    The length-weighting stops broad generic tags from dominating specialised
+    tickets. Example: a solver with ``picks_up=["dev"]`` used to score 0.5 on
+    every ``*-dev`` ticket (equal to a specialist's full substring match),
+    which let catch-all generalists outscore focused specialists on tickets
+    the specialists were hired to own. With weighting, ``"dev"`` (len 3) on
+    ``"frontend-dev"`` (len 12) scores only ``0.5 × 3/12 = 0.125`` — a specialist
+    with exact-match on ``"frontend-dev"`` still wins 1.0 vs 0.125.
+
+    We also bound credit to the *best* partial per ticket tag, so a solver
+    with many redundant variants of the same tag can't stack partial credit.
     """
     score = 0.0
     for tt in ticket_tags:
         if tt in solver_tags:
             score += 1.0
             continue
-        # Substring: does any solver tag appear inside ticket tag or vice-versa?
+        best_partial = 0.0
         for st in solver_tags:
-            if st in tt or tt in st:
-                score += 0.5
-                break
+            if st == tt:
+                # Unreachable via the ``tt in solver_tags`` fast-path, but
+                # defensively handle zero-length pathologies below.
+                continue
+            if not st or not tt:
+                continue
+            if st in tt:
+                ratio = len(st) / len(tt)
+                best_partial = max(best_partial, 0.5 * ratio)
+            elif tt in st:
+                ratio = len(tt) / len(st)
+                best_partial = max(best_partial, 0.5 * ratio)
+        score += best_partial
     return score
 
 
@@ -169,11 +192,52 @@ def update_ticket_sync(**kwargs):
     return _run_async(_update_ticket(**kwargs))
 
 
+# Minimum token gap for a peer to be considered "notably lighter" than
+# the claimer. Small enough to engage the fairness back-off during a
+# busy day, large enough to avoid thrashing around rounding noise.
+_FAIRNESS_MARGIN_TOKENS = 500
+
+
+def _has_lighter_peer_for(
+    ticket: Ticket,
+    peers: Sequence[Persona],
+    claimer_score: float,
+    claimer_tokens: int,
+) -> bool:
+    """Return ``True`` if a peer solver is equally-or-better matched AND less loaded.
+
+    "Less loaded" uses ``tokens_used_today`` with a ``_FAIRNESS_MARGIN_TOKENS``
+    threshold — a peer merely a few tokens behind doesn't trigger back-off.
+    Only invoked from ``claim_next`` so we can defer a claim to let the
+    lighter peer pick the ticket up via the periodic sweep or their own
+    idle event. Without this, a fast solver drains the queue while equal
+    peers idle, even though the push-path (``_assign_to_solver``) is
+    workload-aware — the pull path bypassed it.
+    """
+    ticket_tags = {t.lower() for t in ticket.tags}
+    for peer in peers:
+        peer_tags = {s.lower() for s in (peer.picks_up or peer.skills or [])}
+        if not peer_tags:
+            continue
+        peer_score = _fuzzy_tag_score(peer_tags, ticket_tags)
+        if peer_score < claimer_score:
+            continue
+        peer_tokens = peer.tokens_used_today or 0
+        if peer_tokens + _FAIRNESS_MARGIN_TOKENS < claimer_tokens:
+            return True
+    return False
+
+
 async def claim_next(persona_id: str) -> dict | None:
     """Atomically claim the best open ticket for a persona.
 
-    Uses tag-based matching (picks_up / skills) to find the best fit.
-    Returns a dict with ticket info if claimed, None otherwise.
+    Uses tag-based matching (picks_up / skills) to find the best fit, then
+    applies a fairness back-off: if a peer with equal-or-better match is
+    notably less loaded, skip this ticket and let them pick it up via the
+    sweep or their own idle event. Prevents a fast solver from
+    monopolising the queue while equal peers sit idle.
+
+    Returns a dict with ticket info if claimed, ``None`` otherwise.
     """
     async with async_session() as session:
         persona = await session.get(Persona, persona_id)
@@ -183,6 +247,15 @@ async def claim_next(persona_id: str) -> dict | None:
         picks_up = persona.picks_up or persona.skills or []
         if not picks_up:
             return None
+
+        # Fetch peer solvers once for fairness comparison. Small teams make
+        # this a handful of rows — no need for a smarter query shape.
+        peer_stmt = select(Persona).where(
+            Persona.type == "solver",
+            Persona.status == "active",
+            Persona.id != persona_id,
+        )
+        peers = (await session.execute(peer_stmt)).scalars().all()
 
         result = await session.execute(
             select(Ticket).where(
@@ -206,11 +279,21 @@ async def claim_next(persona_id: str) -> dict | None:
                 scored.append((score, ticket))
         scored.sort(key=lambda p: (-p[0], p[1].id))
 
+        claimer_tokens = persona.tokens_used_today or 0
+
         # Conditional UPDATE: only update if the row is still unassigned and
         # status still open. Rowcount tells us whether we actually won the
         # race — this works on Postgres and SQLite alike without needing
         # SELECT ... FOR UPDATE SKIP LOCKED (which SQLite doesn't support).
         for score, ticket in scored:
+            if _has_lighter_peer_for(ticket, peers, score, claimer_tokens):
+                logger.debug(
+                    "Persona %s backing off ticket #%d (lighter peer available)",
+                    persona_id,
+                    ticket.id,
+                )
+                continue
+
             update_stmt = (
                 update(Ticket)
                 .where(
@@ -233,7 +316,7 @@ async def claim_next(persona_id: str) -> dict | None:
             await session.commit()
 
             logger.info(
-                "Persona %s claimed ticket #%d (score=%.1f)",
+                "Persona %s claimed ticket #%d (score=%.2f)",
                 persona_id,
                 ticket.id,
                 score,

--- a/tests.md
+++ b/tests.md
@@ -1,17 +1,684 @@
 # Test Report
 
-**Date:** 2026-04-24 15:39  
+**Date:** 2026-04-24 15:53  
 
 
 ## Summary
 
 | Metric | Count |
 |--------|-------|
-| Total  | 0 |
-| Passed | 0 |
+| Total  | 462 |
+| Passed | 460 |
 | Failed | 0 |
 | Errors | 0 |
-| Skipped | 0 |
+| Skipped | 2 |
 | **Coverage** | **0%** |
 
 ## Test Results
+
+### test_budget_cov.py (20/20 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_check_budget_nonexistent` | pass |
+| `test_check_budget_unlimited` | pass |
+| `test_check_budget_auto_reset_on_new_day` | pass |
+| `test_check_budget_no_reset_at` | pass |
+| `test_check_budget_exhausted` | pass |
+| `test_check_budget_partial_remaining` | pass |
+| `test_check_budget_unblocks_on_daily_reset` | pass |
+| `test_check_budget_unblocks_unlimited_budget` | pass |
+| `test_check_budget_keeps_blocked_when_still_over` | pass |
+| `test_consume_tokens_zero_total` | pass |
+| `test_consume_tokens_nonexistent` | pass |
+| `test_consume_tokens_accumulates` | pass |
+| `test_consume_tokens_sets_budget_reset_at` | pass |
+| `test_reset_budget_found` | pass |
+| `test_reset_budget_not_found` | pass |
+| `test_reset_all_budgets` | pass |
+| `test_get_budget_status_found` | pass |
+| `test_get_budget_status_not_found` | pass |
+| `test_get_budget_status_unlimited` | pass |
+| `test_get_all_budget_statuses` | pass |
+
+### test_bus.py (2/2 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_publish_serializes_and_sends` | pass |
+| `test_publish_different_event_types` | pass |
+
+### test_bus_cov.py (14/15 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_init_redis_creates_pool_and_client` | pass |
+| `test_init_redis_is_idempotent` | pass |
+| `test_close_redis_cleans_up` | pass |
+| `test_close_redis_noop_when_not_initialized` | pass |
+| `test_get_redis_returns_existing` | pass |
+| `test_get_redis_initializes_lazily` | pass |
+| `test_ping_returns_true_when_reachable` | pass |
+| `test_ping_returns_false_on_error` | pass |
+| `test_ensure_consumer_group_creates_group` | pass |
+| `test_ensure_consumer_group_ignores_busygroup` | pass |
+| `test_ensure_consumer_group_raises_other_errors` | pass |
+| `test_subscribe_processes_messages_and_acks` | pass |
+| `test_subscribe_handles_empty_read` | pass |
+| `test_subscribe_handles_callback_error` | pass |
+| `test_subscribe_retries_on_transient_error` | skip |
+
+### test_company_tools_cov.py (8/8 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_create_role_tool_success` | pass |
+| `test_create_role_tool_no_optional_fields` | pass |
+| `test_create_role_tool_already_exists` | pass |
+| `test_create_role_tool_file_not_found` | pass |
+| `test_fire_persona_tool_delegates` | pass |
+| `test_fire_persona_tool_default_reason` | pass |
+| `test_hire_persona_tool_with_tools_and_picks_up` | pass |
+| `test_list_team_with_reports_to` | pass |
+
+### test_config.py (9/9 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_load_company_config` | pass |
+| `test_get_role` | pass |
+| `test_get_role_missing` | pass |
+| `test_get_org_routing` | pass |
+| `test_load_config_missing_file` | pass |
+| `test_config_caching` | pass |
+| `test_add_role` | pass |
+| `test_add_role_duplicate` | pass |
+| `test_load_real_company_yaml` | pass |
+
+### test_config_roles.py (4/4 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_update_role` | pass |
+| `test_update_role_not_found` | pass |
+| `test_delete_role` | pass |
+| `test_delete_role_not_found` | pass |
+
+### test_dashboard.py (3/3 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_overview_empty` | pass |
+| `test_overview_with_personas_and_tickets` | pass |
+| `test_overview_work_log` | pass |
+
+### test_dashboard_cov.py (13/14 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_serve_dashboard_returns_html` | pass |
+| `test_workspace_file_not_found` | pass |
+| `test_workspace_file_path_traversal` | pass |
+| `test_workspace_serves_existing_file` | pass |
+| `test_overseer_list_messages` | pass |
+| `test_overseer_reply_message_not_found` | pass |
+| `test_overseer_reply_success` | pass |
+| `test_overseer_reply_no_persona` | pass |
+| `test_overview_persona_fields` | pass |
+| `test_soul_update_endpoint` | pass |
+| `test_overview_includes_fired_personas` | pass |
+| `test_overview_includes_reports_to` | pass |
+| `test_patch_persona_config_name_and_role` | pass |
+| `test_dashboard_stream_returns_sse` | skip |
+
+### test_e2e.py (53/53 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_health` | pass |
+| `test_list_personas_empty` | pass |
+| `test_list_personas_seeded` | pass |
+| `test_get_persona` | pass |
+| `test_get_persona_not_found` | pass |
+| `test_create_ticket` | pass |
+| `test_create_ticket_defaults` | pass |
+| `test_list_tickets_by_status` | pass |
+| `test_list_tickets_empty_status` | pass |
+| `test_create_ticket_with_context` | pass |
+| `test_chat_persona_not_found` | pass |
+| `test_chat_with_persona` | pass |
+| `test_chat_returns_agent_response` | pass |
+| `test_ticket_lifecycle` | pass |
+| `test_multiple_tickets_ordering` | pass |
+| `test_engine_auto_assign` | pass |
+| `test_engine_no_solver_available` | pass |
+| `test_seed_company` | pass |
+| `test_seed_company_skips_if_personas_exist` | pass |
+| `test_full_org_is_seeded` | pass |
+| `test_org_roles` | pass |
+| `test_backend_ticket_auto_assigned_to_jamie` | pass |
+| `test_frontend_ticket_auto_assigned_to_sam` | pass |
+| `test_marketing_ticket_auto_assigned` | pass |
+| `test_sales_ticket_auto_assigned` | pass |
+| `test_ceo_ticket_routes_to_pm` | pass |
+| `test_tech_lead_reviews_backlog_via_chat` | pass |
+| `test_full_sprint_lifecycle` | pass |
+| `test_workload_balancing_across_solvers` | pass |
+| `test_seed_real_company_yaml` | pass |
+| `test_fuzzy_tag_matching_exact` | pass |
+| `test_fuzzy_tag_matching_substring` | pass |
+| `test_fuzzy_tag_matching_reverse_substring` | pass |
+| `test_engine_escalates_to_ceo` | pass |
+| `test_sweep_routes_orphaned_tickets` | pass |
+| `test_api_rejects_without_key` | pass |
+| `test_api_rejects_wrong_key` | pass |
+| `test_api_accepts_correct_key` | pass |
+| `test_dashboard_stream_requires_auth` | pass |
+| `test_dashboard_overview_requires_auth` | pass |
+| `test_overseer_messages_requires_auth` | pass |
+| `test_overseer_reply_requires_auth` | pass |
+| `test_budget_check_unlimited` | pass |
+| `test_budget_check_and_consume` | pass |
+| `test_budget_reset` | pass |
+| `test_budget_status` | pass |
+| `test_budget_api_list` | pass |
+| `test_budget_api_reset` | pass |
+| `test_seed_populates_model_id` | pass |
+| `test_engine_budget_blocks_over_budget_persona` | pass |
+| `test_heartbeat_triggers_idle_personas` | pass |
+| `test_heartbeat_skips_busy_personas` | pass |
+| `test_heartbeat_skips_over_budget` | pass |
+
+### test_engine_cov.py (34/34 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_handle_event_dispatches_ticket_created` | pass |
+| `test_handle_event_dispatches_ticket_review` | pass |
+| `test_handle_event_ignores_unknown_type` | pass |
+| `test_handle_event_catches_errors` | pass |
+| `test_set_persona_state` | pass |
+| `test_set_persona_state_missing_persona` | pass |
+| `test_set_ticket_in_progress` | pass |
+| `test_set_ticket_in_progress_skips_done_ticket` | pass |
+| `test_add_ticket_tokens` | pass |
+| `test_add_ticket_tokens_missing_ticket` | pass |
+| `test_trigger_review_falls_back_to_manager` | pass |
+| `test_trigger_review_ticket_not_found` | pass |
+| `test_spawn_persona_task_full_run` | pass |
+| `test_spawn_persona_task_error_sets_blocked` | pass |
+| `test_on_persona_idle_claims_ticket` | pass |
+| `test_on_persona_idle_no_tickets` | pass |
+| `test_on_persona_idle_inactive_persona` | pass |
+| `test_hr_pickup_finds_hr_tagged_tickets` | pass |
+| `test_hr_pickup_ignores_non_hr_tickets` | pass |
+| `test_escalate_to_ceo` | pass |
+| `test_escalate_to_ceo_inactive` | pass |
+| `test_build_task_prompt` | pass |
+| `test_get_routing_target_no_creator` | pass |
+| `test_get_routing_target_by_id` | pass |
+| `test_get_routing_target_by_role_type` | pass |
+| `test_get_routing_target_lead_default` | pass |
+| `test_find_lead_for_tags_exact_match` | pass |
+| `test_find_lead_for_tags_no_match` | pass |
+| `test_sweep_no_orphans` | pass |
+| `test_sweep_handles_route_error` | pass |
+| `test_start_event_listener` | pass |
+| `test_hr_tagged_ticket_routes_to_hr` | pass |
+| `test_route_ticket_skips_assigned` | pass |
+| `test_route_ticket_no_config` | pass |
+
+### test_main.py (14/14 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_app_exists` | pass |
+| `test_app_has_routers` | pass |
+| `test_main_function` | pass |
+| `test_main_function_with_reload` | pass |
+| `test_cors_default_origins` | pass |
+| `test_wait_for_db_success` | pass |
+| `test_wait_for_db_retries_then_succeeds` | pass |
+| `test_wait_for_db_exhausted_retries` | pass |
+| `test_lifespan_startup_shutdown` | pass |
+| `test_lifespan_no_telegram` | pass |
+| `test_root_returns_html` | pass |
+| `test_health_all_ok` | pass |
+| `test_health_db_error` | pass |
+| `test_health_redis_error` | pass |
+
+### test_memory.py (9/9 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_store_and_recall` | pass |
+| `test_recall_filters` | pass |
+| `test_build_memory_context` | pass |
+| `test_build_memory_context_empty` | pass |
+| `test_compaction` | pass |
+| `test_compaction_below_threshold` | pass |
+| `test_remember_tool` | pass |
+| `test_recall_tool` | pass |
+| `test_recall_tool_empty` | pass |
+
+### test_messaging.py (4/4 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_deliver_message_success` | pass |
+| `test_deliver_message_sender_not_found` | pass |
+| `test_deliver_message_recipient_not_found` | pass |
+| `test_deliver_message_recipient_not_active` | pass |
+
+### test_messaging_tools.py (4/4 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_send_message_calls_run_async` | pass |
+| `test_send_message_returns_run_async_result` | pass |
+| `test_contact_overseer_returns_confirmation` | pass |
+| `test_contact_overseer_includes_message_id` | pass |
+
+### test_models.py (4/4 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_persona_creation` | pass |
+| `test_ticket_creation` | pass |
+| `test_persona_defaults` | pass |
+| `test_work_log_creation` | pass |
+
+### test_overseer.py (6/6 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_store_message` | pass |
+| `test_reply_to_message` | pass |
+| `test_reply_to_nonexistent_message` | pass |
+| `test_list_messages_all` | pass |
+| `test_list_messages_pending_only` | pass |
+| `test_list_messages_empty` | pass |
+
+### test_personality.py (4/4 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_personality_injected_in_prompt` | pass |
+| `test_personality_falls_back_to_role` | pass |
+| `test_no_personality_no_crash` | pass |
+| `test_persona_personality_overrides_role` | pass |
+
+### test_personas.py (7/7 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_hire_persona` | pass |
+| `test_hire_duplicate_persona` | pass |
+| `test_fire_persona` | pass |
+| `test_fire_nonexistent_persona` | pass |
+| `test_list_personas` | pass |
+| `test_list_personas_excludes_fired` | pass |
+| `test_list_personas_filter_by_reports_to` | pass |
+
+### test_personas_cov.py (15/15 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_hire_invalid_persona_id` | pass |
+| `test_hire_with_all_optional_fields` | pass |
+| `test_hire_loads_role_config` | pass |
+| `test_hire_post_sweep` | pass |
+| `test_hire_post_sweep_failure` | pass |
+| `test_fire_persona_reassigns_orphaned_tickets` | pass |
+| `test_append_to_company_yaml` | pass |
+| `test_append_to_company_yaml_no_file` | pass |
+| `test_append_to_company_yaml_already_exists` | pass |
+| `test_append_to_company_yaml_exception` | pass |
+| `test_hire_persona_sync_wrapper` | pass |
+| `test_fire_persona_sync_wrapper` | pass |
+| `test_list_personas_sync_wrapper` | pass |
+| `test_list_personas_includes_workload_and_budget` | pass |
+| `test_list_personas_zero_workload_for_idle_persona` | pass |
+
+### test_policy.py (21/21 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_create_policy` | pass |
+| `test_approve_policy` | pass |
+| `test_approve_policy_requires_manager_or_lead` | pass |
+| `test_approve_non_draft_fails` | pass |
+| `test_reject_policy` | pass |
+| `test_reject_policy_requires_manager_or_lead` | pass |
+| `test_list_policies` | pass |
+| `test_get_policy_not_found` | pass |
+| `test_build_policy_context_wildcard` | pass |
+| `test_build_policy_context_role_match` | pass |
+| `test_build_policy_context_persona_id_match` | pass |
+| `test_build_policy_context_tag_skill_match` | pass |
+| `test_build_policy_context_draft_excluded` | pass |
+| `test_build_policy_context_empty` | pass |
+| `test_write_policy_tool` | pass |
+| `test_approve_policy_tool` | pass |
+| `test_approve_policy_tool_error` | pass |
+| `test_list_policies_tool` | pass |
+| `test_list_policies_tool_empty` | pass |
+| `test_read_policy_tool` | pass |
+| `test_read_policy_tool_not_found` | pass |
+
+### test_runner.py (3/3 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_build_system_prompt_from_config` | pass |
+| `test_build_system_prompt_solver` | pass |
+| `test_build_system_prompt_fallback_no_role` | pass |
+
+### test_runner_cov.py (16/16 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_register_tool` | pass |
+| `test_get_model_uses_env_litellm` | pass |
+| `test_get_model_explicit_model_id` | pass |
+| `test_get_model_bedrock_default` | pass |
+| `test_get_model_bedrock_explicit` | pass |
+| `test_create_agent_resolves_tools_from_registry` | pass |
+| `test_create_agent_skips_missing_tools` | pass |
+| `test_create_agent_extra_tools` | pass |
+| `test_create_agent_sets_name_and_description` | pass |
+| `test_agent_result_defaults` | pass |
+| `test_agent_result_with_metrics` | pass |
+| `test_run_persona_happy_path` | pass |
+| `test_run_persona_strips_thinking_tags` | pass |
+| `test_run_persona_extracts_token_metrics` | pass |
+| `test_run_persona_error_handling` | pass |
+| `test_run_persona_metrics_with_none_values` | pass |
+
+### test_scheduler_cov.py (15/15 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_sweep_job_calls_sweep` | pass |
+| `test_sweep_job_handles_exception` | pass |
+| `test_ceo_kickoff_triggers_ceo` | pass |
+| `test_ceo_kickoff_skips_inactive_ceo` | pass |
+| `test_ceo_kickoff_skips_busy_ceo` | pass |
+| `test_ceo_kickoff_skips_over_budget` | pass |
+| `test_ceo_kickoff_handles_exception` | pass |
+| `test_ceo_kickoff_no_ceo` | pass |
+| `test_unblock_personas_job_recovers_blocked` | pass |
+| `test_unblock_personas_job_leaves_still_over_budget` | pass |
+| `test_unblock_personas_job_handles_exception` | pass |
+| `test_start_scheduler_adds_sweep_job` | pass |
+| `test_start_scheduler_with_ceo_kickoff` | pass |
+| `test_start_scheduler_with_heartbeat` | pass |
+| `test_start_scheduler_with_all_jobs` | pass |
+
+### test_sprint1.py (22/22 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_ticket_has_budget_tokens_field` | pass |
+| `test_check_task_budget_requeues_exhausted` | pass |
+| `test_check_task_budget_allows_with_remaining` | pass |
+| `test_check_task_budget_unlimited_when_zero` | pass |
+| `test_claim_next_claims_best_match` | pass |
+| `test_claim_next_returns_none_when_no_tickets` | pass |
+| `test_claim_next_returns_none_for_inactive_persona` | pass |
+| `test_claim_next_skips_assigned_tickets` | pass |
+| `test_claim_next_backs_off_for_lighter_peer` | pass |
+| `test_claim_next_proceeds_when_no_lighter_peer` | pass |
+| `test_claim_next_ignores_peer_with_lower_score` | pass |
+| `test_claim_next_fairness_respects_margin` | pass |
+| `test_capacity_ratio_no_solvers` | pass |
+| `test_capacity_ratio_balanced` | pass |
+| `test_capacity_ratio_counts_assigned_as_pending` | pass |
+| `test_hire_rejected_when_capacity_sufficient` | pass |
+| `test_hire_allowed_when_understaffed` | pass |
+| `test_hire_rejected_at_team_cap` | pass |
+| `test_expires_stale_tickets` | pass |
+| `test_ignores_recent_tickets` | pass |
+| `test_ignores_open_tickets` | pass |
+| `test_expires_stale_assigned_tickets` | pass |
+
+### test_sprint10.py (6/6 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_get_soul` | pass |
+| `test_soul_history` | pass |
+| `test_soul_rollback_api` | pass |
+| `test_entrypoint_script_exists` | pass |
+| `test_entrypoint_has_otel_toggle` | pass |
+| `test_dockerfile_copies_soul_and_sops` | pass |
+
+### test_sprint11_session.py (7/7 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_save_and_load` | pass |
+| `test_load_empty_when_no_session` | pass |
+| `test_save_truncates_to_50` | pass |
+| `test_clear` | pass |
+| `test_load_handles_redis_error` | pass |
+| `test_save_handles_redis_error` | pass |
+| `test_returns_singleton` | pass |
+
+### test_sprint2_events.py (5/5 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_handle_event_dispatches_persona_idle` | pass |
+| `test_handle_event_handles_persona_blocked` | pass |
+| `test_spawn_publishes_idle_on_success` | pass |
+| `test_spawn_publishes_blocked_on_error` | pass |
+| `test_spawn_publishes_blocked_on_budget_exhausted` | pass |
+
+### test_sprint3_metrics.py (2/2 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_metrics_returns_per_persona_data` | pass |
+| `test_metrics_empty_when_no_work` | pass |
+
+### test_sprint4_concurrency.py (3/3 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_concurrent_tasks_blocked_by_semaphore` | pass |
+| `test_get_persona_lock_creates_semaphore` | pass |
+| `test_get_persona_lock_custom_concurrency` | pass |
+
+### test_sprint5_persona_config.py (9/9 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_create_persona_config` | pass |
+| `test_company_snapshot_model` | pass |
+| `test_boot_seeds_from_yaml` | pass |
+| `test_boot_skips_if_already_seeded` | pass |
+| `test_snapshot_captures_state` | pass |
+| `test_snapshot_skips_empty_config` | pass |
+| `test_list_persona_configs` | pass |
+| `test_patch_persona_config` | pass |
+| `test_patch_nonexistent_config` | pass |
+
+### test_sprint6_soul.py (13/13 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_get_version_from_content` | pass |
+| `test_count_rule_changes` | pass |
+| `test_protected_rules_intact` | pass |
+| `test_rejects_same_version` | pass |
+| `test_rejects_too_many_changes` | pass |
+| `test_rejects_missing_protected_rules` | pass |
+| `test_rejects_too_many_lines` | pass |
+| `test_accepts_valid_update` | pass |
+| `test_propose_valid_update` | pass |
+| `test_propose_invalid_rejected` | pass |
+| `test_rollback_to_version` | pass |
+| `test_rollback_nonexistent_version` | pass |
+| `test_soul_injected_into_prompt` | pass |
+
+### test_sprint7.py (7/7 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_researcher_role_exists` | pass |
+| `test_marketer_role_exists` | pass |
+| `test_propose_soul_update_requires_lead` | pass |
+| `test_solver_cannot_propose_soul_update` | pass |
+| `test_lead_can_propose_soul_update` | pass |
+| `test_read_soul_accessible_to_all` | pass |
+| `test_tools_registered` | pass |
+
+### test_sprint8_strands.py (7/7 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_tool_registered` | pass |
+| `test_requires_solver_tier` | pass |
+| `test_external_denied` | pass |
+| `test_solver_allowed` | pass |
+| `test_on_tool_use_records_calls` | pass |
+| `test_on_invocation_complete_consumes_budget` | pass |
+| `test_summary` | pass |
+
+### test_sprint9.py (9/9 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_allows_hire_when_understaffed` | pass |
+| `test_blocks_hire_when_sufficient` | pass |
+| `test_ignores_non_hire_tools` | pass |
+| `test_sop_files_exist` | pass |
+| `test_load_sop_for_review_tag` | pass |
+| `test_load_sop_for_hr_tag` | pass |
+| `test_load_sop_for_unknown_tag` | pass |
+| `test_load_sop_deduplicates` | pass |
+| `test_load_sop_multiple_tags` | pass |
+
+### test_taskboard.py (19/19 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_find_best_solver_matches_skills` | pass |
+| `test_find_best_solver_prefers_lower_workload` | pass |
+| `test_find_best_solver_no_match_falls_back_to_least_busy` | pass |
+| `test_find_best_solver_empty_solvers` | pass |
+| `test_find_best_solver_multiple_tag_overlap` | pass |
+| `test_fuzzy_score_exact_match_full_credit` | pass |
+| `test_fuzzy_score_length_weighted_partial` | pass |
+| `test_fuzzy_score_specialist_outscores_generalist` | pass |
+| `test_fuzzy_score_best_partial_not_summed` | pass |
+| `test_fuzzy_score_ticket_tag_inside_solver_tag` | pass |
+| `test_fuzzy_score_no_overlap` | pass |
+| `test_fuzzy_score_handles_empty_tags` | pass |
+| `test_create_ticket_db` | pass |
+| `test_list_tickets_by_status` | pass |
+| `test_list_tickets_with_tag_filter` | pass |
+| `test_update_ticket_status` | pass |
+| `test_update_ticket_not_found` | pass |
+| `test_update_ticket_result` | pass |
+| `test_update_ticket_review_publishes_event` | pass |
+
+### test_telegram.py (12/12 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_resolve_persona_found` | pass |
+| `test_resolve_persona_not_found` | pass |
+| `test_handle_start_sends_welcome` | pass |
+| `test_handle_start_exception` | pass |
+| `test_handle_message_no_persona` | pass |
+| `test_handle_message_success` | pass |
+| `test_handle_message_long_result` | pass |
+| `test_handle_message_result_no_text_attr` | pass |
+| `test_handle_message_group_chat` | pass |
+| `test_handle_message_exception` | pass |
+| `test_create_telegram_app_no_token` | pass |
+| `test_create_telegram_app_with_token` | pass |
+
+### test_tools.py (22/22 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_ticket_tool_schema` | pass |
+| `test_code_tool_schema` | pass |
+| `test_company_tool_schema` | pass |
+| `test_all_tools_registry` | pass |
+| `test_read_file_returns_contents` | pass |
+| `test_read_file_missing_file` | pass |
+| `test_list_files_shows_directory_contents` | pass |
+| `test_list_files_with_pattern` | pass |
+| `test_grep_code_finds_pattern` | pass |
+| `test_grep_code_no_matches` | pass |
+| `test_create_ticket_tool_calls_sync` | pass |
+| `test_list_tickets_tool_formats_output` | pass |
+| `test_list_tickets_tool_empty` | pass |
+| `test_update_ticket_tool` | pass |
+| `test_hire_persona_tool` | pass |
+| `test_hire_persona_tool_blocked_by_guardrail` | pass |
+| `test_fire_persona_tool` | pass |
+| `test_list_team_tool_with_data` | pass |
+| `test_list_team_tool_unlimited_budget` | pass |
+| `test_list_team_tool_empty` | pass |
+| `test_web_fetch_bad_url` | pass |
+| `test_web_fetch_strips_html` | pass |
+
+### test_trust.py (12/12 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_ceo_gets_full_tier` | pass |
+| `test_hr_gets_full_tier` | pass |
+| `test_manager_gets_full_tier` | pass |
+| `test_solver_gets_solver_tier` | pass |
+| `test_lead_gets_lead_tier` | pass |
+| `test_unknown_type_gets_external_tier` | pass |
+| `test_full_tier_can_use_all_tools` | pass |
+| `test_solver_denied_dangerous_tools` | pass |
+| `test_external_read_only` | pass |
+| `test_lead_tier_access` | pass |
+| `test_web_fetch_requires_solver_tier` | pass |
+| `test_tier_levels_ordered` | pass |
+
+### test_utils.py (4/4 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_set_main_loop_stores_loop` | pass |
+| `test_run_async_fallback_creates_new_loop` | pass |
+| `test_run_async_uses_main_loop_when_running` | pass |
+| `test_run_async_fallback_when_loop_not_running` | pass |
+
+### test_web_tools.py (12/12 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_web_fetch_rejects_ftp_url` | pass |
+| `test_web_fetch_strips_html` | pass |
+| `test_web_fetch_respects_max_chars` | pass |
+| `test_web_fetch_handles_timeout` | pass |
+| `test_web_fetch_handles_encoding_error` | pass |
+| `test_web_fetch_collapses_whitespace` | pass |
+| `test_web_search_no_api_key` | pass |
+| `test_web_search_with_results` | pass |
+| `test_web_search_no_results` | pass |
+| `test_web_search_api_error` | pass |
+| `test_web_search_result_without_snippet` | pass |
+| `test_web_search_limits_to_five_results` | pass |
+
+### test_workspaces.py (7/7 passed) ok
+
+| Test | Status |
+|------|--------|
+| `test_persona_writes_to_private_workspace` | pass |
+| `test_persona_reads_shared_workspace` | pass |
+| `test_publish_file_copies_to_shared` | pass |
+| `test_workspace_path_escape_blocked` | pass |
+| `test_publish_file_requires_persona_id` | pass |
+| `test_publish_file_missing_source` | pass |
+| `test_default_workspace_still_works` | pass |

--- a/tests/test_company_tools_cov.py
+++ b/tests/test_company_tools_cov.py
@@ -119,12 +119,22 @@ def test_fire_persona_tool_default_reason():
 
 def test_hire_persona_tool_with_tools_and_picks_up():
     """hire_persona parses tools and picks_up comma-separated strings."""
+    from unittest.mock import AsyncMock
+
     from opencompany.agents.tools.company import hire_persona
 
-    with patch(
-        "opencompany.company.personas.hire_persona_sync",
-        return_value="Hired Dev (id=dev)",
-    ) as mock:
+    with (
+        # Let the guardrail pass so the hire proceeds.
+        patch(
+            "opencompany.company.personas.capacity_ratio",
+            new_callable=AsyncMock,
+            return_value=3.0,
+        ),
+        patch(
+            "opencompany.company.personas.hire_persona_sync",
+            return_value="Hired Dev (id=dev)",
+        ) as mock,
+    ):
         hire_persona.__wrapped__(
             persona_id="dev",
             name="Dev",

--- a/tests/test_personas_cov.py
+++ b/tests/test_personas_cov.py
@@ -348,3 +348,88 @@ def test_list_personas_sync_wrapper():
         result = list_personas_sync()
     assert result == [{"id": "test"}]
     mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _list_personas — rich return shape with workload + budget signals
+# ---------------------------------------------------------------------------
+async def test_list_personas_includes_workload_and_budget(persona_session):
+    """_list_personas returns workload, budget, activity_state per persona.
+
+    Regression guard: the tool ``list_team`` relies on these fields being
+    present so LLM callers can make informed hire/assign/consolidate
+    decisions. If ``_list_personas`` silently drops them, the tool output
+    degrades to name-only and the guardrails become blind.
+    """
+    from opencompany.company.personas import _list_personas
+
+    async with persona_session() as session:
+        session.add(
+            Persona(
+                id="loaded-dev",
+                name="Loaded Dev",
+                role="Dev",
+                type="solver",
+                backstory="x",
+                activity_state="working",
+                daily_token_budget=10000,
+                tokens_used_today=4500,
+            )
+        )
+        session.add(
+            Ticket(
+                title="In-flight",
+                status="in_progress",
+                assigned_to="loaded-dev",
+            )
+        )
+        session.add(
+            Ticket(
+                title="Queued",
+                status="assigned",
+                assigned_to="loaded-dev",
+            )
+        )
+        # Done tickets do NOT count toward workload.
+        session.add(
+            Ticket(
+                title="Shipped",
+                status="done",
+                assigned_to="loaded-dev",
+            )
+        )
+        await session.commit()
+
+    personas = await _list_personas()
+    assert len(personas) == 1
+    dev = personas[0]
+    assert dev["id"] == "loaded-dev"
+    assert dev["workload"] == 2  # assigned + in_progress
+    assert dev["tokens_used_today"] == 4500
+    assert dev["daily_token_budget"] == 10000
+    assert dev["activity_state"] == "working"
+
+
+async def test_list_personas_zero_workload_for_idle_persona(persona_session):
+    """Personas with no assigned/in_progress tickets report workload=0."""
+    from opencompany.company.personas import _list_personas
+
+    async with persona_session() as session:
+        session.add(
+            Persona(
+                id="idle-dev",
+                name="Idle",
+                role="Dev",
+                type="solver",
+                backstory="x",
+                activity_state="idle",
+                daily_token_budget=0,  # unlimited
+            )
+        )
+        await session.commit()
+
+    personas = await _list_personas()
+    assert len(personas) == 1
+    assert personas[0]["workload"] == 0
+    assert personas[0]["tokens_used_today"] == 0
+    assert personas[0]["daily_token_budget"] == 0

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -213,6 +213,163 @@ class TestClaimNext:
 
         assert result is None
 
+    async def test_claim_next_backs_off_for_lighter_peer(self, factory):
+        """Heavy claimer defers to an equally-matched lighter peer.
+
+        Regression guard: without this, a fast solver who finishes first
+        repeatedly wins pulls and drains the queue while equal-score peers
+        idle. The fairness gate lets the lighter peer pick up the ticket
+        on the next sweep or their own idle event.
+        """
+        async with factory() as session:
+            session.add(
+                Persona(
+                    id="heavy-dev",
+                    name="Heavy",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["python"],
+                    backstory="x",
+                    tokens_used_today=5000,
+                )
+            )
+            session.add(
+                Persona(
+                    id="light-dev",
+                    name="Light",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["python"],
+                    backstory="x",
+                    tokens_used_today=100,
+                )
+            )
+            session.add(Ticket(title="Py task", tags=["python"], status="open"))
+            await session.commit()
+
+        with patch("opencompany.company.taskboard.async_session", factory):
+            result = await claim_next("heavy-dev")
+
+        assert result is None  # heavy-dev backed off
+
+        async with factory() as session:
+            from sqlalchemy import select
+
+            tickets = (await session.execute(select(Ticket))).scalars().all()
+            # Ticket stays open for the lighter peer to grab.
+            assert all(t.status == "open" for t in tickets)
+            assert all(t.assigned_to is None for t in tickets)
+
+    async def test_claim_next_proceeds_when_no_lighter_peer(self, factory):
+        """Lightest solver on the team claims normally (no peer is lighter)."""
+        async with factory() as session:
+            session.add(
+                Persona(
+                    id="light-dev",
+                    name="Light",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["python"],
+                    backstory="x",
+                    tokens_used_today=100,
+                )
+            )
+            session.add(
+                Persona(
+                    id="heavy-dev",
+                    name="Heavy",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["python"],
+                    backstory="x",
+                    tokens_used_today=5000,
+                )
+            )
+            session.add(Ticket(title="Py task", tags=["python"], status="open"))
+            await session.commit()
+
+        with patch("opencompany.company.taskboard.async_session", factory):
+            result = await claim_next("light-dev")
+
+        assert result is not None
+        assert result["title"] == "Py task"
+
+    async def test_claim_next_ignores_peer_with_lower_score(self, factory):
+        """Peers with worse tag match don't trigger the fairness back-off.
+
+        The fairness gate only applies to peers with equal-or-better tag
+        match. A peer who can't do this ticket shouldn't block the only
+        qualified solver from claiming it, even if that peer has less load.
+        """
+        async with factory() as session:
+            session.add(
+                Persona(
+                    id="py-dev",
+                    name="Py",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["python"],
+                    backstory="x",
+                    tokens_used_today=5000,
+                )
+            )
+            # Peer with UNRELATED tag pool — no match for this ticket.
+            session.add(
+                Persona(
+                    id="js-dev",
+                    name="JS",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["javascript"],
+                    backstory="x",
+                    tokens_used_today=100,
+                )
+            )
+            session.add(Ticket(title="Py task", tags=["python"], status="open"))
+            await session.commit()
+
+        with patch("opencompany.company.taskboard.async_session", factory):
+            result = await claim_next("py-dev")
+
+        assert result is not None
+        assert result["title"] == "Py task"
+
+    async def test_claim_next_fairness_respects_margin(self, factory):
+        """Small token differences (below the fairness margin) don't trigger back-off."""
+        async with factory() as session:
+            # Both solvers at roughly the same load (below margin).
+            session.add(
+                Persona(
+                    id="dev-a",
+                    name="A",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["python"],
+                    backstory="x",
+                    tokens_used_today=1000,
+                )
+            )
+            session.add(
+                Persona(
+                    id="dev-b",
+                    name="B",
+                    role="Dev",
+                    type="solver",
+                    picks_up=["python"],
+                    backstory="x",
+                    tokens_used_today=900,  # 100 tokens lighter — below margin of 500
+                )
+            )
+            session.add(Ticket(title="Py task", tags=["python"], status="open"))
+            await session.commit()
+
+        with patch("opencompany.company.taskboard.async_session", factory):
+            result = await claim_next("dev-a")
+
+        # Difference is only 100 tokens — below the fairness margin, so dev-a
+        # still claims rather than back off.
+        assert result is not None
+
 
 # ---------------------------------------------------------------------------
 # P3: Capacity-aware hiring

--- a/tests/test_taskboard.py
+++ b/tests/test_taskboard.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from opencompany.company.taskboard import find_best_solver
+from opencompany.company.taskboard import _fuzzy_tag_score, find_best_solver
 from opencompany.models.db import Persona, Ticket
 
 
@@ -47,6 +48,74 @@ def test_find_best_solver_multiple_tag_overlap():
     ]
     best = find_best_solver(tags=["python", "security"], solvers=solvers)
     assert best["id"] == "dev-1"  # more skill overlap wins despite higher workload
+
+
+# ---------------------------------------------------------------------------
+# _fuzzy_tag_score — length-weighted substring matching
+# ---------------------------------------------------------------------------
+def test_fuzzy_score_exact_match_full_credit():
+    """Exact tag match is worth 1.0 per ticket tag."""
+    assert _fuzzy_tag_score({"python"}, {"python"}) == 1.0
+    assert _fuzzy_tag_score({"python", "backend"}, {"python", "backend"}) == 2.0
+
+
+def test_fuzzy_score_length_weighted_partial():
+    """Short solver tag inside a long ticket tag earns weak partial credit.
+
+    Regression guard: with the old flat-0.5 substring scoring, a broad
+    solver tag ``"dev"`` (len 3) matched every ``*-dev`` ticket at 0.5 —
+    equal to a specialist's exact-match credit on a simpler tag. Now the
+    credit is length-weighted so broad tags get a fraction of the full
+    partial credit.
+    """
+    # "dev" (3) inside "frontend-dev" (12): 0.5 * 3/12 = 0.125
+    score = _fuzzy_tag_score({"dev"}, {"frontend-dev"})
+    assert score == pytest.approx(0.125, abs=0.001)
+
+
+def test_fuzzy_score_specialist_outscores_generalist():
+    """Specialist with exact match beats a broad-tag generalist on the same tag."""
+    specialist = _fuzzy_tag_score({"frontend-dev"}, {"frontend-dev"})
+    generalist = _fuzzy_tag_score({"dev"}, {"frontend-dev"})
+    assert specialist == 1.0
+    assert generalist < 0.2
+    assert specialist > generalist
+
+
+def test_fuzzy_score_best_partial_not_summed():
+    """Multiple substring hits per ticket tag don't stack — best wins.
+
+    Prevents a solver with many redundant variant tags from accruing
+    disproportionate score. Under the old algorithm, each matching solver
+    tag simply added 0.5 (via ``break`` per ticket tag) — which *did*
+    prevent stacking, but the shorter tag still got full 0.5 credit.
+    Here we check both: length-weight applies AND best-partial wins.
+    """
+    # "dev" (3) in "frontend-react-dev" (18): 0.5 * 3/18 ≈ 0.083
+    # "react" (5) in "frontend-react-dev" (18): 0.5 * 5/18 ≈ 0.139
+    # Best wins → 0.139, NOT summed 0.222
+    score = _fuzzy_tag_score({"dev", "react"}, {"frontend-react-dev"})
+    assert score == pytest.approx(0.5 * 5 / 18, abs=0.001)
+
+
+def test_fuzzy_score_ticket_tag_inside_solver_tag():
+    """Ticket tag contained in a longer solver tag earns partial credit."""
+    # "backend" (7) in "backend-dev" (11): 0.5 * 7/11 ≈ 0.318
+    score = _fuzzy_tag_score({"backend-dev"}, {"backend"})
+    assert score == pytest.approx(0.5 * 7 / 11, abs=0.001)
+
+
+def test_fuzzy_score_no_overlap():
+    """Completely unrelated tags earn 0."""
+    assert _fuzzy_tag_score({"python"}, {"rust"}) == 0.0
+    assert _fuzzy_tag_score({"frontend"}, {"database"}) == 0.0
+
+
+def test_fuzzy_score_handles_empty_tags():
+    """Empty tag sets don't explode."""
+    assert _fuzzy_tag_score(set(), {"python"}) == 0.0
+    assert _fuzzy_tag_score({"python"}, set()) == 0.0
+    assert _fuzzy_tag_score(set(), set()) == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -182,12 +182,22 @@ def test_update_ticket_tool():
 # ---------------------------------------------------------------------------
 def test_hire_persona_tool():
     """hire_persona tool parses comma-separated skills."""
+    from unittest.mock import AsyncMock
+
     from opencompany.agents.tools.company import hire_persona
 
-    with patch(
-        "opencompany.company.personas.hire_persona_sync",
-        return_value="Hired Alex as Dev (id=new-dev)",
-    ) as mock:
+    with (
+        # Let the guardrail pass (capacity ratio >= threshold = understaffed).
+        patch(
+            "opencompany.company.personas.capacity_ratio",
+            new_callable=AsyncMock,
+            return_value=3.0,
+        ),
+        patch(
+            "opencompany.company.personas.hire_persona_sync",
+            return_value="Hired Alex as Dev (id=new-dev)",
+        ) as mock,
+    ):
         result = hire_persona.__wrapped__(
             persona_id="new-dev",
             name="Alex",
@@ -200,6 +210,42 @@ def test_hire_persona_tool():
     assert "Hired Alex" in result
     call_kwargs = mock.call_args[1]
     assert call_kwargs["skills"] == ["python", "backend"]
+
+
+def test_hire_persona_tool_blocked_by_guardrail():
+    """hire_persona returns the guardrail's steering message when team has capacity.
+
+    Regression guard: the tool must short-circuit on guardrail steering —
+    otherwise the agent sees a success-ish message ``Hired …`` when in
+    fact no hire happened, or a hard error from the DB-layer check that
+    reads less usefully than the guardrail's directive.
+    """
+    from unittest.mock import AsyncMock
+
+    from opencompany.agents.tools.company import hire_persona
+
+    with (
+        patch(
+            "opencompany.company.personas.capacity_ratio",
+            new_callable=AsyncMock,
+            return_value=0.5,  # team has plenty of capacity — don't hire.
+        ),
+        patch(
+            "opencompany.company.personas.hire_persona_sync",
+        ) as hire_mock,
+    ):
+        result = hire_persona.__wrapped__(
+            persona_id="redundant",
+            name="Redundant",
+            role="Dev",
+            persona_type="solver",
+            skills="python",
+            backstory="Not needed.",
+        )
+
+    assert "GUARDRAIL" in result
+    assert "Do NOT hire" in result
+    hire_mock.assert_not_called()
 
 
 def test_fire_persona_tool():
@@ -216,11 +262,21 @@ def test_fire_persona_tool():
 
 
 def test_list_team_tool_with_data():
-    """list_team tool formats persona data into readable lines."""
+    """list_team tool formats persona data into readable lines with workload."""
     from opencompany.agents.tools.company import list_team
 
     mock_personas = [
-        {"id": "dev-1", "name": "Jamie", "role": "Dev", "type": "solver", "skills": ["python"]},
+        {
+            "id": "dev-1",
+            "name": "Jamie",
+            "role": "Dev",
+            "type": "solver",
+            "skills": ["python"],
+            "activity_state": "idle",
+            "workload": 2,
+            "tokens_used_today": 500,
+            "daily_token_budget": 1000,
+        },
     ]
 
     with patch("opencompany.company.personas.list_personas_sync", return_value=mock_personas):
@@ -229,6 +285,36 @@ def test_list_team_tool_with_data():
     assert "Jamie" in result
     assert "Dev" in result
     assert "solver" in result
+    assert "workload=2" in result
+    assert "state=idle" in result
+    # Budget formatted as used/total with percent.
+    assert "tokens=500/1000" in result
+    assert "50%" in result
+
+
+def test_list_team_tool_unlimited_budget():
+    """list_team tool formats unlimited-budget personas distinctly."""
+    from opencompany.agents.tools.company import list_team
+
+    mock_personas = [
+        {
+            "id": "ceo",
+            "name": "Alice",
+            "role": "CEO",
+            "type": "manager",
+            "skills": ["strategy"],
+            "activity_state": "idle",
+            "workload": 0,
+            "tokens_used_today": 1200,
+            "daily_token_budget": 0,  # unlimited
+        },
+    ]
+
+    with patch("opencompany.company.personas.list_personas_sync", return_value=mock_personas):
+        result = list_team.__wrapped__()
+
+    assert "unlimited" in result
+    assert "tokens=1200" in result
 
 
 def test_list_team_tool_empty():


### PR DESCRIPTION
Follow-up to #84. Audit items **#4–#6** from the team-logic review.

The **push path** (``_assign_to_solver``) was workload-aware. The **pull path** (``claim_next``) and the **scoring function** (``_fuzzy_tag_score``) were not, so in practice a single fast persona with a broad tag would drain the queue while equal-score specialists idled.

## Three fixes

### 1. Length-weighted fuzzy tag scoring

**Before:** flat ``0.5`` for any substring overlap in either direction.

A solver with ``picks_up=[\"dev\"]`` scored ``0.5`` on *every* ``*-dev`` ticket — same as a specialist's full match — so broad generalists out-scored focused specialists on tickets meant for the specialist.

**After:** ``0.5 × (shorter / longer)``. ``\"dev\"`` (3) on ``\"frontend-dev\"`` (12) → ``0.125``, not ``0.5``. A specialist with exact ``\"frontend-dev\"`` wins 1.0 vs 0.125. Also bounds to the best partial per ticket tag so a solver with many redundant variant tags can't stack credit.

### 2. Workload-aware ``claim_next``

**Before:** first idle with best tag match always claimed. No peer comparison. A fast solver with ``picks_up=[\"python\"]`` and 5000 tokens already burned today kept pulling Python tickets while equal peers at 100 tokens idled.

**After:** ``claim_next`` fetches active peer solvers and checks if any has **equal-or-better tag match AND less ``tokens_used_today``** (by at least ``_FAIRNESS_MARGIN_TOKENS`` = 500). If so, skip the claim; the lighter peer picks it up via scheduled sweep or their own idle event. The margin prevents thrashing around rounding noise.

### 3. ``HiringGuardrail`` wired in + richer ``list_team``

``HiringGuardrail`` was **dead in production**: defined in ``agents/hooks.py`` with tests in ``test_sprint9.py``, but no production code imported it. Steering-message logic only ran in unit tests.

**After:**
- ``hire_persona`` tool invokes the guardrail before the hire. Over-staffing attempts get corrective steering instead of (in addition to) a hard-block error from ``_hire_persona``.
- ``list_team`` tool output now includes ``activity_state``, ``workload`` (assigned + in_progress), ``tokens_used_today`` / ``daily_token_budget``. Agents can now *see* who's loaded and reassign existing team members rather than grow headcount blindly.

## Test plan

- [x] 7 new ``_fuzzy_tag_score`` tests: exact, length-weighted partial, specialist > generalist, best-partial (not sum), both substring directions, no overlap, empty sets
- [x] 4 new ``claim_next`` tests: heavy backs off for lighter peer, lightest proceeds, lower-score peer ignored, fairness margin respected
- [x] 2 new ``_list_personas`` tests: workload counts ``assigned + in_progress``, zero-workload case, unlimited-budget formatting
- [x] 2 new ``hire_persona`` / ``list_team`` tool tests: guardrail short-circuits the hire, list_team renders new fields + handles unlimited budget
- [x] Existing tests updated where mocking expanded (2 tests: ``test_hire_persona_tool``, ``test_hire_persona_tool_with_tools_and_picks_up``)
- [x] Full suite: **460 passed, 2 skipped** (up from 445; +15 net)
- [x] ``ruff check`` + ``ruff format --check`` clean

## Not in this PR

The remaining audit follow-ups are smaller and can wait:

- Split ``engine.py`` (~640 LoC) by concern (routing / assignment / budget)
- Tiny-budget requeue loop guard on tickets with ``budget_tokens`` just under ``_MIN_USEFUL_TOKENS``
- Replace ``urllib`` with ``httpx`` in ``web.py``
- Evaluate ``CompanyHooks`` wiring — if we adopt it, drop the engine's token-consume block to avoid double-charging