### PR TITLE
chore(deps): bump Strands to 1.37.0 / 0.5.1 (cooldown exception)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,23 @@ override-dependencies = [
     "python-dotenv>=1.2.2",
 ]
 
+# ---------------------------------------------------------------------------
+# Cooldown exceptions.
+#
+# The default uv cooldown (``exclude-newer-span = "P7D"``) blocks any package
+# uploaded within the last 7 days — a sensible supply-chain safeguard against
+# recently-compromised releases. We override it for Strands because we track
+# upstream tightly: the SDK is AWS-maintained, releases are small (mostly bug
+# fixes and telemetry improvements), and the RSS ``get_feed_file_path``
+# path-traversal fix in tools 0.5.0 is worth picking up promptly even though
+# we don't use RSS tools today.
+#
+# Cutoff is set a day past the current strands release (2026-04-22) so any
+# surprise release gets the standard cooldown. Bump when upgrading again.
+[tool.uv.exclude-newer-package]
+"strands-agents" = "2026-04-25"
+"strands-agents-tools" = "2026-04-25"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests.md
+++ b/tests.md
@@ -1,6 +1,6 @@
 # Test Report
 
-**Date:** 2026-04-24 15:53  
+**Date:** 2026-04-24 16:16  
 
 
 ## Summary

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,12 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-17T13:05:42.730402Z"
+exclude-newer = "2026-04-17T14:14:25.327075Z"
 exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+strands-agents = "2026-04-25T22:00:00Z"
+strands-agents-tools = "2026-04-25T22:00:00Z"
 
 [manifest]
 overrides = [
@@ -1757,7 +1761,7 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.35.0"
+version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -1773,14 +1777,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/30/e183d3e7b170c9579eb315fc598ea7fea86670f8f1fe9541dba8ecc29812/strands_agents-1.35.0.tar.gz", hash = "sha256:913a598529bf73fe48c47b15aedb31679192cbe218e2d4aa71c62a06d63d5d73", size = 801382, upload-time = "2026-04-08T20:05:33.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/88/cf23aa713ea68c8a0ad5144341da7ee022e88ce6206512aeafddba257b75/strands_agents-1.37.0.tar.gz", hash = "sha256:3fe6821f730f0468eee91e1ff38eb27a5244046893ffba63e8f5345288096509", size = 824168, upload-time = "2026-04-22T19:18:01.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/4a/0599f483220b08772000ec8fdb86b8cb1d624f51bab546af41bce3a0eac2/strands_agents-1.35.0-py3-none-any.whl", hash = "sha256:d34c749742b63bbaef90057ac1cbd5c04fb9e1e50fcda58741eb0af0ab0aeb91", size = 394806, upload-time = "2026-04-08T20:05:30.871Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ff/bede1b8d5fe1c776bd5ed33575505681b3b65ab20889fe6b8344b92fc82d/strands_agents-1.37.0-py3-none-any.whl", hash = "sha256:2fa12e22ed1dac228aa93e91c2ea5381d9b3f08416ed8162222b61b255fee0b1", size = 404526, upload-time = "2026-04-22T19:17:59.634Z" },
 ]
 
 [[package]]
 name = "strands-agents-tools"
-version = "0.4.1"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1801,9 +1805,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/7a/9f8d9868768669dd658f1c424534ef8e0aef4d7bb44af70c102f08041efa/strands_agents_tools-0.4.1.tar.gz", hash = "sha256:4d5c77fe6019b89d483bea2a5ad41bd1b56f17b0f696b7aa06be31cca73344e1", size = 480977, upload-time = "2026-04-09T14:09:17.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/fc/8a9da78b5c4a8802367a8eeec046f98eda742b1ee1b2fff568c81c1b3479/strands_agents_tools-0.5.1.tar.gz", hash = "sha256:616ba88b5849d9fd495da057ccb670108580320b8cb0fc4faac5fc327f2622aa", size = 483123, upload-time = "2026-04-22T20:01:13.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/93/0f04a8fd253df239792b79f5578679e3112e3f8ff69d26301190f7f9f890/strands_agents_tools-0.4.1-py3-none-any.whl", hash = "sha256:6736c54237270114aeb90d57a5fb8ccd2a363a22bab4feddc472755873bf7b0a", size = 315607, upload-time = "2026-04-09T14:09:15.577Z" },
+    { url = "https://files.pythonhosted.org/packages/64/59/79360f718683ae15cefeb8b0ca1e6d96608c4581280fb12b0f502375a705/strands_agents_tools-0.5.1-py3-none-any.whl", hash = "sha256:790865d073410e9a16ac44ce3a46c169b98e1f89844ce8670472b869257b7686", size = 316122, upload-time = "2026-04-22T20:01:11.599Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- ``strands-agents`` 1.35.0 → **1.37.0**
- ``strands-agents-tools`` 0.4.1 → **0.5.1**
- Adds ``[tool.uv.exclude-newer-package]`` override to keep us on the latest Strands even within uv's 7-day supply-chain cooldown

## Context

Both packages released 2026-04-22 (2 days ago). uv's default lockfile cooldown (``exclude-newer-span = \"P7D\"``) blocks anything uploaded within 7 days — a sensible default for supply-chain hygiene. For Strands specifically we track upstream tightly, so this PR adds a per-package cooldown exception:

\`\`\`toml
[tool.uv.exclude-newer-package]
\"strands-agents\" = \"2026-04-25\"
\"strands-agents-tools\" = \"2026-04-25\"
\`\`\`

Cutoff is set a day past the current release so any *surprise* release still gets the default cooldown. Bump the dates next time we upgrade.

## What's in these releases

- **SDK 1.35 → 1.37** (spans 1.36 and 1.37): telemetry gen_ai attributes fix, MCP interpreter-finalization cleanup, SlidingWindowConversationManager trim fallback, agent snapshot methods, per-invocation usage in span attributes, context_window_limit config, Bedrock empty-tool-result normalization, LiteLLM Gemini thought_signature fix, hook callable accepted in Agent constructor.
- **Tools 0.4.1 → 0.5.1**: **path-traversal fix** in the RSS ``get_feed_file_path`` helper (GHSA equivalent, via [#451](https://github.com/strands-agents/tools/pull/451)); Exa search gained highlights / max_age_hours / new categories. We don't expose RSS tools today, so the fix is nice-to-have rather than urgent.

## Supply-chain verification

| Artifact | SHA256 | Matches PyPI |
|---|---|---|
| ``strands_agents-1.37.0.tar.gz`` | ``3fe6821f…096509`` | ✓ |
| ``strands_agents-1.37.0-py3-none-any.whl`` | ``2fa12e22…fee0b1`` | ✓ |
| ``strands_agents_tools-0.5.1.tar.gz`` | ``616ba88b…2622aa`` | ✓ |
| ``strands_agents_tools-0.5.1-py3-none-any.whl`` | ``790865d0…b7686`` | ✓ |

Maintainer: ``AWS <opensource@amazon.com>`` (both packages).

## Supersedes

- **#51** (strands-agents → 1.29.0): bumping TO an older version than main already had. Closed.
- **#52** (strands-agents-tools → 0.2.22): same, also CONFLICTING. Closed.

## Test plan

- [x] ``uv lock`` without CLI flags produces the same lock — confirms the pyproject exception is persistent
- [x] ``uv sync`` installs 1.37.0 / 0.5.1
- [x] Full unit suite: **460 passed, 2 skipped**
- [x] ``ruff check`` clean
- [x] Sha256 hashes captured in ``uv.lock`` match PyPI's published values