### PR TITLE
fix(engine): stability pass — 9 correctness & responsiveness fixes

### DIFF
--- a/src/opencompany/company/engine.py
+++ b/src/opencompany/company/engine.py
@@ -103,7 +103,10 @@ async def _on_persona_idle(persona_id: str) -> None:
             f"solve-ticket-{claimed['id']}",
             ticket_id=claimed["id"],
         )
-    elif persona_id == "hr":
+    elif (persona.role or "").lower() == "hr":
+        # Any active persona with role='hr' handles HR pickup — previously
+        # this was hardcoded to ``persona_id == 'hr'`` which broke if the
+        # HR persona was renamed, or if multiple HR personas existed.
         await _hr_pickup()
 
 
@@ -137,10 +140,17 @@ async def _route_ticket(ticket_id: int):
         creator_id = ticket.created_by
         creator = await session.get(Persona, creator_id) if creator_id else None
 
-        # HR-tagged tickets always go to HR
+        # HR-tagged tickets always go to HR. Look up the active HR persona
+        # by role rather than assuming a persona literally named ``"hr"``.
         if "hr" in ticket.tags or "hiring" in ticket.tags:
-            logger.info("Ticket #%d has HR tag, routing directly to HR", ticket_id)
-            target_id = "hr"
+            target_id = await _find_hr_persona_id(session)
+            if target_id:
+                logger.info("Ticket #%d has HR tag, routing to %s", ticket_id, target_id)
+            else:
+                logger.warning(
+                    "Ticket #%d has HR tag but no active HR persona — falling back",
+                    ticket_id,
+                )
         else:
             target_type = _get_routing_target(creator, config, routing)
             logger.info(
@@ -179,11 +189,14 @@ async def _route_ticket(ticket_id: int):
             await _assign_to_solver(ticket, session)
             return
 
-        ticket.assigned_to = target_id
-        ticket.status = "assigned"
-        log = WorkLog(persona_id=target_id, action="picked_up", ticket_id=ticket_id)
-        session.add(log)
-        await session.commit()
+        won = await _try_claim_ticket(session, ticket_id, target_id)
+        if not won:
+            logger.info(
+                "Ticket #%d already claimed by another router — skipping %s",
+                ticket_id,
+                target_id,
+            )
+            return
         logger.info(
             "Routed ticket #%d to %s (%s)",
             ticket_id,
@@ -278,6 +291,41 @@ def _find_lead_for_tags(tags: list[str], config) -> str | None:
     return best_match
 
 
+async def _try_claim_ticket(
+    session,
+    ticket_id: int,
+    target_persona_id: str,
+    action: str = "picked_up",
+) -> bool:
+    """Atomically flip a ticket from open → assigned for a specific persona.
+
+    Uses a conditional UPDATE (``WHERE status='open' AND assigned_to IS NULL``)
+    so two routers racing on the same ticket can't both think they've
+    assigned it — ``rowcount`` tells us which call won. Critical once the
+    deployment scales beyond a single instance, where the event loop no
+    longer serialises ``handle_event`` across consumers. On a single-instance
+    deployment this is a no-op cost (few microseconds) but cheap insurance.
+    Returns True on win, False if another caller got there first.
+    """
+    from sqlalchemy import update
+
+    stmt = (
+        update(Ticket)
+        .where(
+            Ticket.id == ticket_id,
+            Ticket.status == "open",
+            Ticket.assigned_to.is_(None),
+        )
+        .values(status="assigned", assigned_to=target_persona_id)
+    )
+    result = await session.execute(stmt)
+    if result.rowcount != 1:
+        return False
+    session.add(WorkLog(persona_id=target_persona_id, action=action, ticket_id=ticket_id))
+    await session.commit()
+    return True
+
+
 async def _assign_to_solver(ticket: Ticket, session) -> None:
     """Assign a ticket to the best available solver."""
     solvers = await _get_solvers_with_workload()
@@ -300,11 +348,13 @@ async def _assign_to_solver(ticket: Ticket, session) -> None:
         await _escalate_to_ceo(ticket, session)
         return
 
-    ticket.assigned_to = best["id"]
-    ticket.status = "assigned"
-    log = WorkLog(persona_id=best["id"], action="picked_up", ticket_id=ticket.id)
-    session.add(log)
-    await session.commit()
+    won = await _try_claim_ticket(session, ticket.id, best["id"])
+    if not won:
+        logger.info(
+            "Ticket #%d already claimed by another router — skipping solver assign",
+            ticket.id,
+        )
+        return
     logger.info("Assigned ticket #%d to solver %s", ticket.id, best["id"])
 
     persona = await session.get(Persona, best["id"])
@@ -387,7 +437,12 @@ async def _get_solvers_with_workload() -> list[dict]:
 
 
 async def _trigger_review(ticket_id: int):
-    """Trigger reviewer for a completed ticket."""
+    """Trigger reviewer for a completed ticket.
+
+    Prefers the ticket's creator. Falls back to any active manager,
+    **excluding the worker who submitted the ticket for review** — letting
+    a persona review their own work silently nullifies the review step.
+    """
     logger.info("Triggering review for ticket #%d", ticket_id)
     async with async_session() as session:
         ticket = await session.get(Ticket, ticket_id)
@@ -395,13 +450,21 @@ async def _trigger_review(ticket_id: int):
             logger.warning("Ticket #%d not found for review", ticket_id)
             return
 
-        reviewer = await session.get(Persona, ticket.created_by)
+        reviewer = None
+        if ticket.created_by and ticket.created_by != ticket.assigned_to:
+            reviewer = await session.get(Persona, ticket.created_by)
+
         if not reviewer:
             logger.info(
-                "Creator %s not found, falling back to manager",
+                "Creator %s unavailable (or same as worker), falling back to a manager",
                 ticket.created_by,
             )
-            q = select(Persona).where(Persona.type == "manager", Persona.status == "active")
+            q = select(Persona).where(
+                Persona.type == "manager",
+                Persona.status == "active",
+                # Never route the review back to the worker.
+                Persona.id != ticket.assigned_to,
+            )
             result = await session.execute(q)
             reviewer = result.scalars().first()
 
@@ -444,6 +507,14 @@ def _spawn_persona_task(persona: Persona, task: str, label: str, ticket_id: int 
                 persona.id,
                 label,
             )
+            # Immediate recovery: if a ticket was already flipped to
+            # ``assigned`` but we can't actually start work, unset the
+            # assignment and republish so another persona can grab it
+            # right now. Without this the ticket would sit ``assigned``
+            # until stale-reclaim catches it (~10 minutes) — a dead zone
+            # that stacks up under sustained contention.
+            if ticket_id is not None:
+                await _release_ticket_for_retry(ticket_id, persona.id, reason="lock_held")
             return
 
         try:
@@ -514,6 +585,50 @@ def _spawn_persona_task(persona: Persona, task: str, label: str, ticket_id: int 
     logger.info("Spawned background task: %s", label)
 
 
+async def _release_ticket_for_retry(ticket_id: int, persona_id: str, reason: str) -> None:
+    """Put a ticket back to the open pool and republish so another persona retries.
+
+    Only flips the ticket if it is still ``assigned`` to the caller —
+    conditional UPDATE, so a later race that already moved the ticket
+    forward (e.g. the ``in_progress`` flip) is not clobbered.
+    """
+    async with async_session() as session:
+        from sqlalchemy import update
+
+        stmt = (
+            update(Ticket)
+            .where(
+                Ticket.id == ticket_id,
+                Ticket.status == "assigned",
+                Ticket.assigned_to == persona_id,
+            )
+            .values(status="open", assigned_to=None)
+        )
+        result = await session.execute(stmt)
+        if result.rowcount != 1:
+            # Ticket is no longer in ``assigned`` for this persona — it
+            # either already started, was reclaimed, or doesn't exist.
+            # Nothing to do.
+            return
+        session.add(
+            WorkLog(
+                persona_id=persona_id,
+                action="released",
+                ticket_id=ticket_id,
+                details=reason,
+            )
+        )
+        await session.commit()
+    try:
+        await publish("ticket.created", {"ticket_id": ticket_id})
+    except Exception:
+        logger.exception(
+            "Failed to republish ticket #%d after release (reason=%s) — sweep will catch it",
+            ticket_id,
+            reason,
+        )
+
+
 async def _set_ticket_in_progress(ticket_id: int, persona_id: str) -> None:
     """Mark a ticket as in_progress when a solver starts working on it."""
     async with async_session() as session:
@@ -545,12 +660,22 @@ async def _add_ticket_tokens(ticket_id: int, tokens_in: int, tokens_out: int) ->
 
 
 _MIN_USEFUL_TOKENS = 200
+# Upper bound on how many times a ticket may be requeued for budget_exhausted
+# before we park it as ``needs_attention``. Without this guard, a ticket
+# whose remaining budget is just below ``_MIN_USEFUL_TOKENS`` enters a
+# livelock: requeue → route → budget check fails (no tokens consumed, so
+# ``used`` never grows) → requeue → … forever, spamming WorkLog and DB.
+_MAX_BUDGET_REQUEUES = 3
 
 
 async def _check_task_budget(ticket_id: int, persona_id: str) -> bool:
     """Check if a ticket has enough per-task budget remaining for meaningful work.
 
-    Returns True if work should proceed, False if ticket was requeued.
+    Returns True if work should proceed, False if the ticket was requeued
+    or parked. A ticket that would otherwise loop indefinitely (remaining
+    budget < ``_MIN_USEFUL_TOKENS`` but no tokens actually consumed
+    between requeues) gets parked at ``status='needs_attention'`` once
+    it has been requeued ``_MAX_BUDGET_REQUEUES`` times.
     """
     async with async_session() as session:
         ticket = await session.get(Ticket, ticket_id)
@@ -558,26 +683,63 @@ async def _check_task_budget(ticket_id: int, persona_id: str) -> bool:
             return True  # 0 = unlimited
         used = (ticket.tokens_in or 0) + (ticket.tokens_out or 0)
         remaining = ticket.budget_tokens - used
-        if remaining < _MIN_USEFUL_TOKENS:
-            logger.warning(
-                "Ticket #%d budget exhausted (%d/%d used), requeuing",
+        if remaining >= _MIN_USEFUL_TOKENS:
+            return True
+
+        # Count prior budget_exhausted requeues on this ticket. ``WorkLog``
+        # is our audit trail, so no schema change needed — the requeue
+        # entries we emit below are the source of truth.
+        prior_requeues = (
+            await session.execute(
+                select(func.count(WorkLog.id)).where(
+                    WorkLog.ticket_id == ticket_id,
+                    WorkLog.action == "requeued",
+                    WorkLog.details == "budget_exhausted",
+                )
+            )
+        ).scalar() or 0
+
+        if prior_requeues >= _MAX_BUDGET_REQUEUES:
+            logger.error(
+                "Ticket #%d stuck in requeue loop (%d prior requeues, %d/%d used) — parking",
                 ticket_id,
+                prior_requeues,
                 used,
                 ticket.budget_tokens,
             )
-            ticket.status = "open"
+            ticket.status = "needs_attention"
             ticket.assigned_to = None
-            log = WorkLog(
+            session.add(
+                WorkLog(
+                    persona_id=persona_id,
+                    action="parked",
+                    ticket_id=ticket_id,
+                    details=f"requeue_loop (n={prior_requeues})",
+                )
+            )
+            await session.commit()
+            return False
+
+        logger.warning(
+            "Ticket #%d budget exhausted (%d/%d used), requeuing (attempt %d)",
+            ticket_id,
+            used,
+            ticket.budget_tokens,
+            prior_requeues + 1,
+        )
+        ticket.status = "open"
+        ticket.assigned_to = None
+        session.add(
+            WorkLog(
                 persona_id=persona_id,
                 action="requeued",
                 ticket_id=ticket_id,
                 details="budget_exhausted",
             )
-            session.add(log)
-            await session.commit()
-            await publish("ticket.created", {"ticket_id": ticket_id})
-            return False
-    return True
+        )
+        await session.commit()
+        await publish("ticket.created", {"ticket_id": ticket_id})
+        return False
 
 
 async def _check_task_budget_post_run(ticket_id: int) -> None:
@@ -597,6 +759,24 @@ async def _check_task_budget_post_run(ticket_id: int) -> None:
 
 
 _HR_TAGS = {"hr", "hiring", "firing", "headcount", "personnel", "recruit"}
+
+
+async def _find_hr_persona_id(session) -> str | None:
+    """Return the id of an active HR persona (by role='hr'), or None.
+
+    Queries by role rather than by a hardcoded persona ID so the feature
+    survives renaming the builtin ``hr`` persona or creating additional
+    HR personas. If multiple match, the first one is returned — for now
+    we don't distribute HR work across multiple HR personas.
+    """
+    result = await session.execute(
+        select(Persona).where(
+            func.lower(Persona.role) == "hr",
+            Persona.status == "active",
+        )
+    )
+    hr = result.scalars().first()
+    return hr.id if hr else None
 
 
 async def _hr_pickup() -> None:

--- a/src/opencompany/company/personas.py
+++ b/src/opencompany/company/personas.py
@@ -257,22 +257,38 @@ async def _fire_persona(persona_id: str, reason: str = "") -> str:
                 Ticket.status.in_(("open", "assigned", "in_progress")),
             )
         )
-        orphan_count = 0
+        orphan_ids: list[int] = []
         for ticket in orphaned.scalars().all():
             ticket.status = "open"
             ticket.assigned_to = None
-            orphan_count += 1
+            orphan_ids.append(ticket.id)
 
         await session.commit()
 
-        if orphan_count:
-            logger.info(
-                "Reassigned %d orphaned tickets from fired persona %s",
-                orphan_count,
+    # Publish AFTER commit + outside the session so the engine re-routes
+    # each orphan immediately rather than waiting for the next 30-second
+    # sweep. Importing locally keeps ``personas`` free of ``engine`` and
+    # ``events`` at import time (avoids circular imports).
+    from opencompany.events.bus import publish
+
+    for ticket_id in orphan_ids:
+        try:
+            await publish("ticket.created", {"ticket_id": ticket_id})
+        except Exception:
+            logger.exception(
+                "Failed to republish ticket #%d after firing %s — sweep will catch it",
+                ticket_id,
                 persona_id,
             )
-        logger.info("Fired persona %s (%s). Reason: %s", persona_id, persona.name, reason)
-        return f"Fired {persona.name} ({persona_id}). Reason: {reason}"
+
+    if orphan_ids:
+        logger.info(
+            "Reassigned %d orphaned tickets from fired persona %s",
+            len(orphan_ids),
+            persona_id,
+        )
+    logger.info("Fired persona %s (%s). Reason: %s", persona_id, persona.name, reason)
+    return f"Fired {persona.name} ({persona_id}). Reason: {reason}"
 
 
 def fire_persona_sync(**kwargs) -> str:

--- a/src/opencompany/company/scheduler.py
+++ b/src/opencompany/company/scheduler.py
@@ -96,16 +96,40 @@ HEARTBEAT_PROMPTS = {
 
 
 async def _persona_heartbeat_job():
-    """Periodic heartbeat: idle personas check in and take autonomous action."""
+    """Periodic heartbeat: idle personas check in and take autonomous action.
+
+    Gated on "is there anything worth checking in on?" — without the gate,
+    every idle persona burned tokens on every tick regardless of board
+    state. At a 60-second heartbeat with 12 personas that's ~17k no-op
+    prompts per day on an empty board. We now only fire if there's at
+    least one open ticket OR one ticket that's been stuck ``in_progress``
+    longer than ``_STALE_MINUTES`` (meaning the current owner needs help).
+    """
     try:
-        from sqlalchemy import select
+        from sqlalchemy import and_, func, or_, select
 
         from opencompany.company.budget import check_budget
         from opencompany.company.engine import _spawn_persona_task
-        from opencompany.models.db import Persona
+        from opencompany.models.db import Persona, Ticket
         from opencompany.models.engine import async_session
 
         async with async_session() as session:
+            stale_cutoff = datetime.now(UTC) - timedelta(minutes=_STALE_MINUTES)
+            has_work = await session.scalar(
+                select(func.count(Ticket.id)).where(
+                    or_(
+                        Ticket.status == "open",
+                        and_(
+                            Ticket.status == "in_progress",
+                            Ticket.updated_at < stale_cutoff,
+                        ),
+                    )
+                )
+            )
+            if not has_work:
+                logger.debug("Heartbeat: no open or stuck tickets — skipping")
+                return
+
             result = await session.execute(
                 select(Persona).where(
                     Persona.status == "active",
@@ -266,19 +290,23 @@ async def _unblock_personas_job():
     without this sweep a once-blocked persona stays orphaned forever — even
     after their daily budget auto-resets.
 
-    ``check_budget`` has the side effect of un-blocking a persona when their
-    budget is available, so we simply iterate all blocked personas and call
-    it. Personas that come back to ``idle`` get a ``persona.idle`` event so
-    the engine immediately tries to assign them work.
+    Flips blocked→idle inline in a single session (no ping-pong through
+    ``check_budget`` for each persona). A persona is un-blocked when their
+    daily budget is unlimited OR their daily budget reset has already
+    happened OR they have budget headroom. Each unblocked persona gets
+    a ``persona.idle`` event so the engine assigns them work immediately.
     """
     try:
+        from datetime import UTC as _UTC
+        from datetime import datetime as _dt
+
         from sqlalchemy import select
 
-        from opencompany.company.budget import check_budget
         from opencompany.events.bus import publish
         from opencompany.models.db import Persona
         from opencompany.models.engine import async_session
 
+        unblocked_ids: list[str] = []
         async with async_session() as session:
             result = await session.execute(
                 select(Persona).where(
@@ -287,27 +315,34 @@ async def _unblock_personas_job():
                 )
             )
             blocked = result.scalars().all()
+            now = _dt.now(_UTC)
+            for persona in blocked:
+                # Auto-reset daily tokens if we've crossed a day boundary.
+                if persona.daily_token_budget > 0 and (
+                    persona.budget_reset_at is None or persona.budget_reset_at.date() < now.date()
+                ):
+                    persona.tokens_used_today = 0
+                    persona.budget_reset_at = now
 
-        if not blocked:
-            return
+                has_budget = (
+                    persona.daily_token_budget == 0
+                    or (persona.tokens_used_today or 0) < persona.daily_token_budget
+                )
+                if has_budget:
+                    persona.activity_state = "idle"
+                    unblocked_ids.append(persona.id)
 
-        unblocked: list[str] = []
-        for persona in blocked:
-            # check_budget flips blocked→idle when budget is available.
-            has_budget, _ = await check_budget(persona.id)
-            if not has_budget:
-                continue
-            # Re-read to confirm the flip actually happened.
-            async with async_session() as session:
-                refreshed = await session.get(Persona, persona.id)
-                if refreshed and refreshed.activity_state == "idle":
-                    unblocked.append(persona.id)
+            if unblocked_ids:
+                await session.commit()
 
-        for pid in unblocked:
-            await publish("persona.idle", {"persona_id": pid})
+        for pid in unblocked_ids:
+            try:
+                await publish("persona.idle", {"persona_id": pid})
+            except Exception:
+                logger.exception("Failed to publish persona.idle for %s", pid)
 
-        if unblocked:
-            logger.info("Unblocked %d personas: %s", len(unblocked), unblocked)
+        if unblocked_ids:
+            logger.info("Unblocked %d personas: %s", len(unblocked_ids), unblocked_ids)
     except Exception:
         logger.exception("Unblock personas job failed")
 

--- a/src/opencompany/company/taskboard.py
+++ b/src/opencompany/company/taskboard.py
@@ -58,10 +58,16 @@ def _fuzzy_tag_score(solver_tags: set[str], ticket_tags: set[str]) -> float:
 
 
 def find_best_solver(tags: list[str], solvers: list[dict]) -> dict | None:
-    """Find the best solver for a ticket based on skill overlap and workload.
+    """Find the best-matched solver for a ticket.
 
-    Uses fuzzy tag matching (exact + substring) and falls back to the least
-    busy solver if no match is found.
+    Returns the highest-scoring solver (score > 0) by skill overlap, with
+    workload as a tiebreaker. Returns ``None`` when no solver has a
+    positive tag-match score — this lets the caller escalate the ticket
+    to the CEO rather than blindly dumping a ``["blockchain"]`` ticket on
+    the least-busy Python specialist. A "least-busy fallback" at this
+    layer was a silent correctness bug: the escalation path in
+    ``_assign_to_solver`` only fired on an empty solver pool, which
+    almost never happens in practice.
     """
     if not solvers:
         return None
@@ -72,7 +78,7 @@ def find_best_solver(tags: list[str], solvers: list[dict]) -> dict | None:
         solver_tags = {s.lower() for s in solver["skills"]}
         score = _fuzzy_tag_score(solver_tags, ticket_tags)
         logger.debug(
-            "Solver scoring: %s score=%.1f workload=%d (skills=%s vs tags=%s)",
+            "Solver scoring: %s score=%.2f workload=%d (skills=%s vs tags=%s)",
             solver["id"],
             score,
             solver["workload"],
@@ -82,23 +88,22 @@ def find_best_solver(tags: list[str], solvers: list[dict]) -> dict | None:
         if score > 0:
             candidates.append((score, solver["workload"], solver))
 
-    if candidates:
-        # Sort by score (desc), workload (asc), random tiebreaker
-        # Without the random factor, the same solver always wins when tied
-        candidates.sort(key=lambda x: (-x[0], x[1], random.random()))
-        best = candidates[0]
-        logger.info(
-            "Best solver: %s (score=%.1f, workload=%d, %d candidates)",
-            best[2]["id"],
-            best[0],
-            best[1],
-            len(candidates),
-        )
-        return candidates[0][2]
+    if not candidates:
+        logger.info("No tag match for %s — caller should escalate", tags)
+        return None
 
-    # Fallback: assign to a random least-busy solver
-    logger.info("No tag match for %s, falling back to least busy solver", tags)
-    return min(solvers, key=lambda s: (s["workload"], random.random()))
+    # Sort by score (desc), workload (asc), random tiebreaker. Without
+    # the random factor, the same solver always wins when tied.
+    candidates.sort(key=lambda x: (-x[0], x[1], random.random()))
+    best = candidates[0]
+    logger.info(
+        "Best solver: %s (score=%.2f, workload=%d, %d candidates)",
+        best[2]["id"],
+        best[0],
+        best[1],
+        len(candidates),
+    )
+    return best[2]
 
 
 async def _create_ticket(

--- a/tests.md
+++ b/tests.md
@@ -1,14 +1,14 @@
 # Test Report
 
-**Date:** 2026-04-24 16:16  
+**Date:** 2026-04-24 16:57  
 
 
 ## Summary
 
 | Metric | Count |
 |--------|-------|
-| Total  | 462 |
-| Passed | 460 |
+| Total  | 471 |
+| Passed | 469 |
 | Failed | 0 |
 | Errors | 0 |
 | Skipped | 2 |
@@ -131,7 +131,7 @@
 | `test_patch_persona_config_name_and_role` | pass |
 | `test_dashboard_stream_returns_sse` | skip |
 
-### test_e2e.py (53/53 passed) ok
+### test_e2e.py (54/54 passed) ok
 
 | Test | Status |
 |------|--------|
@@ -186,10 +186,11 @@
 | `test_seed_populates_model_id` | pass |
 | `test_engine_budget_blocks_over_budget_persona` | pass |
 | `test_heartbeat_triggers_idle_personas` | pass |
+| `test_heartbeat_skips_when_no_work` | pass |
 | `test_heartbeat_skips_busy_personas` | pass |
 | `test_heartbeat_skips_over_budget` | pass |
 
-### test_engine_cov.py (34/34 passed) ok
+### test_engine_cov.py (41/41 passed) ok
 
 | Test | Status |
 |------|--------|
@@ -205,6 +206,13 @@
 | `test_add_ticket_tokens_missing_ticket` | pass |
 | `test_trigger_review_falls_back_to_manager` | pass |
 | `test_trigger_review_ticket_not_found` | pass |
+| `test_trigger_review_excludes_worker_from_fallback` | pass |
+| `test_trigger_review_prefers_non_worker_creator` | pass |
+| `test_release_ticket_for_retry_flips_open` | pass |
+| `test_release_ticket_noop_when_already_started` | pass |
+| `test_try_claim_ticket_wins_first` | pass |
+| `test_find_hr_persona_id_by_role` | pass |
+| `test_find_hr_persona_id_none_when_missing` | pass |
 | `test_spawn_persona_task_full_run` | pass |
 | `test_spawn_persona_task_error_sets_blocked` | pass |
 | `test_on_persona_idle_claims_ticket` | pass |
@@ -415,7 +423,7 @@
 | `test_start_scheduler_with_heartbeat` | pass |
 | `test_start_scheduler_with_all_jobs` | pass |
 
-### test_sprint1.py (22/22 passed) ok
+### test_sprint1.py (23/23 passed) ok
 
 | Test | Status |
 |------|--------|
@@ -423,6 +431,7 @@
 | `test_check_task_budget_requeues_exhausted` | pass |
 | `test_check_task_budget_allows_with_remaining` | pass |
 | `test_check_task_budget_unlimited_when_zero` | pass |
+| `test_check_task_budget_parks_after_loop_threshold` | pass |
 | `test_claim_next_claims_best_match` | pass |
 | `test_claim_next_returns_none_when_no_tickets` | pass |
 | `test_claim_next_returns_none_for_inactive_persona` | pass |
@@ -566,7 +575,7 @@
 |------|--------|
 | `test_find_best_solver_matches_skills` | pass |
 | `test_find_best_solver_prefers_lower_workload` | pass |
-| `test_find_best_solver_no_match_falls_back_to_least_busy` | pass |
+| `test_find_best_solver_no_match_returns_none` | pass |
 | `test_find_best_solver_empty_solvers` | pass |
 | `test_find_best_solver_multiple_tag_overlap` | pass |
 | `test_fuzzy_score_exact_match_full_credit` | pass |

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1547,7 +1547,7 @@ async def test_engine_budget_blocks_over_budget_persona(db_engine):
 
 
 async def test_heartbeat_triggers_idle_personas(db_engine):
-    """Heartbeat job spawns tasks for idle personas with budget."""
+    """Heartbeat job spawns tasks for idle personas with budget when work exists."""
     factory = async_sessionmaker(db_engine, expire_on_commit=False)
 
     async with factory() as session:
@@ -1562,6 +1562,9 @@ async def test_heartbeat_triggers_idle_personas(db_engine):
                 daily_token_budget=100000,
             )
         )
+        # Heartbeat now gates on "is there work worth checking in on?" —
+        # we seed at least one open ticket so the gate opens.
+        session.add(Ticket(title="Work to do", tags=["x"], status="open"))
         await session.commit()
 
     with (
@@ -1577,6 +1580,42 @@ async def test_heartbeat_triggers_idle_personas(db_engine):
     call_args = mock_spawn.call_args
     assert call_args[0][0].id == "idle-dev"
     assert "heartbeat-idle-dev" in call_args[0][2]
+
+
+async def test_heartbeat_skips_when_no_work(db_engine):
+    """Heartbeat skips entirely when there are no open or stuck tickets.
+
+    Regression guard for the token-burn issue: an empty board with 12
+    idle personas at a 60-second heartbeat used to emit 17k no-op
+    prompts per day. The gate prevents that.
+    """
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="idle-only",
+                name="Idle Only",
+                role="Dev",
+                type="solver",
+                backstory="x",
+                activity_state="idle",
+                daily_token_budget=100000,
+            )
+        )
+        # NO open or in_progress tickets → heartbeat should no-op.
+        await session.commit()
+
+    with (
+        patch("opencompany.models.engine.async_session", factory),
+        patch("opencompany.company.budget.async_session", factory),
+        patch("opencompany.company.engine._spawn_persona_task") as mock_spawn,
+    ):
+        from opencompany.company.scheduler import _persona_heartbeat_job
+
+        await _persona_heartbeat_job()
+
+    mock_spawn.assert_not_called()
 
 
 async def test_heartbeat_skips_busy_personas(db_engine):

--- a/tests/test_engine_cov.py
+++ b/tests/test_engine_cov.py
@@ -279,6 +279,255 @@ async def test_trigger_review_ticket_not_found(db_engine):
         await _trigger_review(99999)
 
 
+async def test_trigger_review_excludes_worker_from_fallback(db_engine):
+    """If the only manager IS the worker, review falls through to nobody.
+
+    Regression guard: routing a review back to the worker who submitted
+    the ticket silently nullifies the review step. The manager fallback
+    must exclude ``ticket.assigned_to``.
+    """
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        # Only manager on the team is also the worker — should NOT be
+        # chosen as reviewer.
+        session.add(
+            Persona(
+                id="worker-mgr",
+                name="Working Manager",
+                role="Lead",
+                type="manager",
+                backstory="Submitted this ticket and shouldn't review it.",
+            )
+        )
+        ticket = Ticket(
+            title="Submitted for review",
+            priority="high",
+            status="review",
+            tags=["x"],
+            result="Done",
+            assigned_to="worker-mgr",
+            created_by="ghost",  # creator unavailable → fallback path
+        )
+        session.add(ticket)
+        await session.commit()
+        await session.refresh(ticket)
+        ticket_id = ticket.id
+
+    with (
+        patch("opencompany.company.engine.async_session", factory),
+        patch("opencompany.company.engine._spawn_persona_task") as mock_spawn,
+    ):
+        from opencompany.company.engine import _trigger_review
+
+        await _trigger_review(ticket_id)
+
+    # No reviewer was spawned because the only manager == the worker.
+    mock_spawn.assert_not_called()
+
+
+async def test_trigger_review_prefers_non_worker_creator(db_engine):
+    """Creator gets the review unless creator == worker."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="creator-mgr",
+                name="Creator",
+                role="PM",
+                type="manager",
+                backstory="x",
+            )
+        )
+        session.add(
+            Persona(
+                id="worker",
+                name="Worker",
+                role="Dev",
+                type="solver",
+                backstory="x",
+            )
+        )
+        ticket = Ticket(
+            title="Review me",
+            status="review",
+            tags=["x"],
+            result="Done",
+            assigned_to="worker",
+            created_by="creator-mgr",
+        )
+        session.add(ticket)
+        await session.commit()
+        await session.refresh(ticket)
+        ticket_id = ticket.id
+
+    with (
+        patch("opencompany.company.engine.async_session", factory),
+        patch("opencompany.company.engine._spawn_persona_task") as mock_spawn,
+    ):
+        from opencompany.company.engine import _trigger_review
+
+        await _trigger_review(ticket_id)
+
+    mock_spawn.assert_called_once()
+    assert mock_spawn.call_args[0][0].id == "creator-mgr"
+
+
+# ---------------------------------------------------------------------------
+# _release_ticket_for_retry — immediate recovery when a spawn is dropped
+# ---------------------------------------------------------------------------
+async def test_release_ticket_for_retry_flips_open(db_engine):
+    """Release a stuck ``assigned`` ticket back to the open pool and republish."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        ticket = Ticket(
+            title="Stuck",
+            status="assigned",
+            assigned_to="busy-dev",
+            tags=["x"],
+        )
+        session.add(ticket)
+        await session.commit()
+        await session.refresh(ticket)
+        tid = ticket.id
+
+    published = []
+
+    async def fake_publish(event_type, data):
+        published.append((event_type, data))
+
+    with (
+        patch("opencompany.company.engine.async_session", factory),
+        patch("opencompany.company.engine.publish", fake_publish),
+    ):
+        from opencompany.company.engine import _release_ticket_for_retry
+
+        await _release_ticket_for_retry(tid, "busy-dev", "lock_held")
+
+    async with factory() as session:
+        ticket = await session.get(Ticket, tid)
+        assert ticket is not None
+        assert ticket.status == "open"
+        assert ticket.assigned_to is None
+
+    assert ("ticket.created", {"ticket_id": tid}) in published
+
+
+async def test_release_ticket_noop_when_already_started(db_engine):
+    """Conditional UPDATE refuses to rewind a ticket that's already in_progress."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        ticket = Ticket(
+            title="In flight",
+            status="in_progress",  # not 'assigned' — release should no-op
+            assigned_to="busy-dev",
+            tags=["x"],
+        )
+        session.add(ticket)
+        await session.commit()
+        await session.refresh(ticket)
+        tid = ticket.id
+
+    with (
+        patch("opencompany.company.engine.async_session", factory),
+        patch("opencompany.company.engine.publish", new_callable=AsyncMock) as mock_publish,
+    ):
+        from opencompany.company.engine import _release_ticket_for_retry
+
+        await _release_ticket_for_retry(tid, "busy-dev", "lock_held")
+
+    async with factory() as session:
+        ticket = await session.get(Ticket, tid)
+        assert ticket is not None
+        assert ticket.status == "in_progress"  # untouched
+        assert ticket.assigned_to == "busy-dev"
+
+    # No republish because no actual release happened.
+    mock_publish.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _try_claim_ticket — optimistic locking for routing
+# ---------------------------------------------------------------------------
+async def test_try_claim_ticket_wins_first(db_engine):
+    """First claimer wins; second sees rowcount=0 and returns False."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        ticket = Ticket(title="Compete", status="open", tags=["x"])
+        session.add(ticket)
+        await session.commit()
+        await session.refresh(ticket)
+        tid = ticket.id
+
+    from opencompany.company.engine import _try_claim_ticket
+
+    async with factory() as session:
+        won = await _try_claim_ticket(session, tid, "dev-a")
+    assert won is True
+
+    # Second attempt: ticket is no longer status='open', should refuse.
+    async with factory() as session:
+        won2 = await _try_claim_ticket(session, tid, "dev-b")
+    assert won2 is False
+
+    async with factory() as session:
+        ticket = await session.get(Ticket, tid)
+        assert ticket is not None
+        assert ticket.assigned_to == "dev-a"
+
+
+# ---------------------------------------------------------------------------
+# _find_hr_persona_id — role-based lookup
+# ---------------------------------------------------------------------------
+async def test_find_hr_persona_id_by_role(db_engine):
+    """Matches by role='hr', not persona ID."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        # Renamed HR persona — role is still 'hr' but id is 'maria'.
+        session.add(
+            Persona(
+                id="maria",
+                name="Maria",
+                role="hr",
+                type="manager",
+                backstory="x",
+            )
+        )
+        await session.commit()
+
+        from opencompany.company.engine import _find_hr_persona_id
+
+        hr_id = await _find_hr_persona_id(session)
+    assert hr_id == "maria"
+
+
+async def test_find_hr_persona_id_none_when_missing(db_engine):
+    """Returns None when no active HR persona exists."""
+    factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            Persona(
+                id="dev",
+                name="Dev",
+                role="Dev",
+                type="solver",
+                backstory="x",
+            )
+        )
+        await session.commit()
+
+        from opencompany.company.engine import _find_hr_persona_id
+
+        hr_id = await _find_hr_persona_id(session)
+    assert hr_id is None
+
+
 # ---------------------------------------------------------------------------
 # _spawn_persona_task — full lifecycle
 # ---------------------------------------------------------------------------

--- a/tests/test_personas_cov.py
+++ b/tests/test_personas_cov.py
@@ -174,7 +174,11 @@ async def test_hire_post_sweep_failure(persona_session):
 # _fire_persona edge cases
 # ---------------------------------------------------------------------------
 async def test_fire_persona_reassigns_orphaned_tickets(persona_session):
-    """Firing a persona reassigns their in-progress tickets to open pool."""
+    """Firing a persona reassigns their in-progress tickets to open pool.
+
+    Also republishes ``ticket.created`` for each orphan so routing fires
+    immediately rather than waiting for the 30-second sweep.
+    """
     async with persona_session() as session:
         session.add(
             Persona(
@@ -210,11 +214,18 @@ async def test_fire_persona_reassigns_orphaned_tickets(persona_session):
         )
         await session.commit()
 
-    result = await _fire_persona("busy-dev", reason="restructure")
+    published: list[tuple[str, dict]] = []
+
+    async def fake_publish(event_type, data):
+        published.append((event_type, data))
+
+    with patch("opencompany.events.bus.publish", fake_publish):
+        result = await _fire_persona("busy-dev", reason="restructure")
     assert "Fired Busy Dev" in result
 
     async with persona_session() as session:
         persona = await session.get(Persona, "busy-dev")
+        assert persona is not None
         assert persona.status == "fired"
 
         from sqlalchemy import select
@@ -227,6 +238,11 @@ async def test_fire_persona_reassigns_orphaned_tickets(persona_session):
         assert len(done_tickets) == 1
         for t in open_tickets:
             assert t.assigned_to is None
+
+    # Exactly two ticket.created events — one per reclaimed orphan.
+    created_events = [d for e, d in published if e == "ticket.created"]
+    assert len(created_events) == 2
+    assert all("ticket_id" in d for d in created_events)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -106,6 +106,62 @@ class TestPerTaskBudget:
 
         assert result is True
 
+    async def test_check_task_budget_parks_after_loop_threshold(self, factory):
+        """Ticket is parked as ``needs_attention`` after repeated budget requeues.
+
+        Regression guard for the requeue livelock: a ticket whose remaining
+        budget is just below ``_MIN_USEFUL_TOKENS`` but which never actually
+        consumes tokens (spawn dies before run_persona) used to oscillate
+        forever between ``open`` and ``assigned``. After ``_MAX_BUDGET_REQUEUES``
+        requeues the ticket is parked so an operator can intervene.
+        """
+        from opencompany.models.db import WorkLog
+
+        async with factory() as session:
+            session.add(Persona(id="dev", name="Dev", role="Dev", type="solver", backstory="x"))
+            ticket = Ticket(
+                title="Loop",
+                tags=["x"],
+                budget_tokens=300,
+                tokens_in=150,
+                tokens_out=0,  # remaining = 150 < 200 triggers requeue
+                status="assigned",
+                assigned_to="dev",
+            )
+            session.add(ticket)
+            await session.commit()
+            await session.refresh(ticket)
+            tid = ticket.id
+            # Seed prior requeue audit entries to hit the park threshold.
+            for _ in range(3):
+                session.add(
+                    WorkLog(
+                        persona_id="dev",
+                        action="requeued",
+                        ticket_id=tid,
+                        details="budget_exhausted",
+                    )
+                )
+            await session.commit()
+
+        with (
+            patch("opencompany.company.engine.async_session", factory),
+            patch("opencompany.company.engine.publish", new_callable=AsyncMock) as mock_publish,
+        ):
+            from opencompany.company.engine import _check_task_budget
+
+            result = await _check_task_budget(tid, "dev")
+
+        assert result is False
+        # No republish — we park instead of re-queueing again.
+        mock_publish.assert_not_awaited()
+
+        async with factory() as session:
+            ticket = await session.get(Ticket, tid)
+            assert ticket is not None
+            assert ticket.status == "needs_attention"
+            assert ticket.assigned_to is None
+
 
 # ---------------------------------------------------------------------------
 # P2: Pull-based claim_next

--- a/tests/test_taskboard.py
+++ b/tests/test_taskboard.py
@@ -27,13 +27,20 @@ def test_find_best_solver_prefers_lower_workload():
     assert best["id"] == "dev-2"
 
 
-def test_find_best_solver_no_match_falls_back_to_least_busy():
+def test_find_best_solver_no_match_returns_none():
+    """With zero tag matches we return None so the caller can escalate.
+
+    Previously we fell back to ``min(solvers, key=workload)`` here, which
+    silently dumped ``["blockchain"]`` tickets on the least-busy Python
+    dev. The escalation path in ``_assign_to_solver`` is the right place
+    for unmatched tags — this just unblocks it.
+    """
     solvers = [
         {"id": "dev-1", "skills": ["python"], "workload": 3},
         {"id": "dev-2", "skills": ["java"], "workload": 1},
     ]
     best = find_best_solver(tags=["rust"], solvers=solvers)
-    assert best["id"] == "dev-2"  # least busy gets it
+    assert best is None
 
 
 def test_find_best_solver_empty_solvers():


### PR DESCRIPTION
Third stability PR on the team engine (follow-up to #84 and #85). Nine independent fixes, bundled because they're small and share files.

## Correctness (bugs with real user-visible impact)

1. **Requeue-loop livelock** — ``_check_task_budget`` re-queued tickets whose remaining budget fell below ``_MIN_USEFUL_TOKENS``, but no tokens were consumed between attempts (spawn dies before ``run_persona``), so tickets oscillated ``open → assigned → open → …`` forever. Now counts prior ``budget_exhausted`` WorkLog entries and parks the ticket at ``status='needs_attention'`` after ``_MAX_BUDGET_REQUEUES`` (3) attempts.
2. **``find_best_solver`` misroutes unknown-skill tickets** — fallback was \"least-busy solver\" regardless of tag match. A ``[\"blockchain\"]`` ticket got dumped on a random Python dev. The CEO escalation branch in ``_assign_to_solver`` never fired because ``find_best_solver`` always returned somebody. Now returns ``None`` on zero matches so escalation works.
3. **``_trigger_review`` self-review** — when the creator was unavailable the fallback picked any active manager, including the worker who submitted. A persona reviewing their own work is a silent correctness bug. Now both branches exclude ``ticket.assigned_to``.

## Responsiveness (UX / latency)

4. **``_fire_persona`` orphan re-routing** — fired personas' in-flight tickets were set back to ``open`` but no event was published, so orphans waited up to 30 s for the next sweep. Now publishes ``ticket.created`` per orphan after the DB commit.
5. **Silent spawn-drop recovery** — when ``_spawn_persona_task`` found the per-persona semaphore already held, the ticket sat ``assigned`` for up to 10 minutes before stale-reclaim. New helper ``_release_ticket_for_retry`` flips it back to ``open`` via a conditional UPDATE and republishes ``ticket.created`` immediately.

## Robustness (multi-instance & rename-safety)

6. **Hardcoded ``\"hr\"`` persona ID** — two places in ``engine.py`` assumed a persona literally named ``\"hr\"``. Renaming the builtin or running multiple HR personas broke routing + idle-pickup silently. Now resolved via ``_find_hr_persona_id(session)`` which queries ``role='hr'``.
7. **Routing race across instances** — ``_route_ticket`` and ``_assign_to_solver`` did read-modify-write without optimistic locking. Single-process is safe (event loop serialises ``handle_event``) but two pods could both \"assign\" the same ticket. New ``_try_claim_ticket`` helper uses conditional UPDATE + ``rowcount`` check so the loser gracefully backs off.

## Polish (cost & cleanup)

8. **Heartbeat gate** — every idle persona got a heartbeat prompt every tick regardless of board state (~17k tokens/day burned on an empty board with 12 personas at 60 s interval). Now gated on \"at least one open ticket OR one stuck ``in_progress``\" before spawning any heartbeats.
9. **``_unblock_personas_job`` single session** — old version opened 3 sessions per blocked persona (list, check_budget, refresh). Now one session, inline flip, one commit. Publishes happen outside the session.

## Tests

Nine new tests covering each behaviour + regression guards. Full suite: **469 passed, 2 skipped** (up from 460). Ruff clean. Pre-commit hooks green.

| # | New test | Guards |
|---|---|---|
| 1 | ``test_check_task_budget_parks_after_loop_threshold`` | Park at 3 requeues |
| 2 | ``test_find_best_solver_no_match_returns_none`` | Return None on unmatched tags |
| 3 | ``test_trigger_review_excludes_worker_from_fallback`` | Worker can't self-review |
| 3b | ``test_trigger_review_prefers_non_worker_creator`` | Creator wins when available |
| 4 | ``test_fire_persona_reassigns_orphaned_tickets`` (updated) | Publishes ``ticket.created`` |
| 5 | ``test_release_ticket_for_retry_flips_open`` | Release on spawn-drop |
| 5b | ``test_release_ticket_noop_when_already_started`` | Conditional UPDATE safety |
| 6 | ``test_find_hr_persona_id_by_role`` + ``_none_when_missing`` | Role-based lookup |
| 7 | ``test_try_claim_ticket_wins_first`` | Optimistic locking |
| 8 | ``test_heartbeat_skips_when_no_work`` | No-work gate |

## Deferred from the audit

- **#10 Rolling-window fairness** — ``tokens_used_today`` is a full-day cumulative. A persona who burned budget in the morning still looks \"heavy\" at 4 pm. Fixing needs either a time-bucketed token table or a decay function; not small enough for this PR.
- **#11 Hire TOCTOU** — ``count-then-insert`` race on headcount. Only matters multi-instance (single-process serialises via event loop) and fixing properly wants a DB-level unique constraint on ``(role, status)`` via alembic migration. Filed for a follow-up dep-migration PR.